### PR TITLE
Alter payment flow to match GOV.UK api and MTP api changes

### DIFF
--- a/mtp_send_money/settings/base.py
+++ b/mtp_send_money/settings/base.py
@@ -23,7 +23,7 @@ DEBUG = True
 SECRET_KEY = 'CHANGE_ME'
 ALLOWED_HOSTS = []
 
-SITE_URL = os.environ.get('SITE_URL', 'localhost')
+SITE_URL = os.environ.get('SITE_URL', 'http://localhost:8004')
 
 # Application definition
 INSTALLED_APPS = (
@@ -222,7 +222,6 @@ ZENDESK_CUSTOM_FIELDS = {
 HIDE_BANK_TRANSFER_OPTION = True
 
 GOVUK_PAY_URL = os.environ.get('GOVUK_PAY_URL', '')
-GOVUK_PAY_ACCOUNT_ID = os.environ.get('GOVUK_PAY_ACCOUNT_ID', '')
 GOVUK_PAY_AUTH_TOKEN = os.environ.get('GOVUK_PAY_AUTH_TOKEN', '')
 
 

--- a/mtp_send_money/templates/send_money/send-money.html
+++ b/mtp_send_money/templates/send_money/send-money.html
@@ -101,9 +101,8 @@
         </style>
       {% endif %}
 
-{% comment %}
+      {% csrf_token %}
       {{ form.as_p }}
-{% endcomment %}
 
       <p>
         <input id="id_next_btn" class="button" type="submit" value="{% trans 'Continue' %}">


### PR DESCRIPTION
Now creates Payments on the MTP API instead of transactions.
A Payment has a UUID primary key which is then used as the
payment reference for a GOV.UK payment.