### PR TITLE
Add app name to url configuration to prevent deprecation warnings

### DIFF
--- a/mtp_send_money/apps/send_money/urls.py
+++ b/mtp_send_money/apps/send_money/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 
 from send_money import views
 
+app_name = 'send_money'
 urlpatterns = [
     url(r'^$', views.SendMoneyView.as_view(), name='send_money'),
     url(r'^bank-transfer/$', views.bank_transfer_view, name='bank_transfer'),


### PR DESCRIPTION
only needed when urls are included with a namespace