### PR TITLE
Include service charge in requests to MTP API and GOV.UK

### DIFF
--- a/mtp_send_money/apps/send_money/tests/test_views.py
+++ b/mtp_send_money/apps/send_money/tests/test_views.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+import json
 import unittest
 from unittest import mock
 
@@ -271,6 +272,13 @@ class DebitCardViewTestCase(BaseTestCase):
                 status=200,
             )
             response = self.client.get(self.url, follow=False)
+
+            # check amount and service charge submitted to api
+            self.assertEqual(json.loads(rsps.calls[1].request.body)['amount'], 1000)
+            self.assertEqual(json.loads(rsps.calls[1].request.body)['service_charge'], 44)
+            # check total charge submitted to govuk
+            self.assertEqual(json.loads(rsps.calls[2].request.body)['amount'], 1044)
+
             self.assertRedirects(
                 response, govuk_url(self.payment_process_path),
                 fetch_redirect_response=False

--- a/mtp_send_money/apps/send_money/views.py
+++ b/mtp_send_money/apps/send_money/views.py
@@ -14,7 +14,7 @@ from send_money.forms import PaymentMethod, SendMoneyForm
 from send_money.utils import (
     unserialise_amount, unserialise_date, bank_transfer_reference,
     govuk_headers, govuk_url, get_api_client, site_url, get_link_by_rel,
-    get_total_charge
+    get_total_charge, get_service_charge
 )
 
 logger = logging.getLogger('mtp')
@@ -168,8 +168,11 @@ def debit_card_view(request, context):
     @param request: the HTTP request
     @param context: the template context
     """
+    amount_pence = int(context['amount'] * 100)
+    service_charge_pence = int(get_service_charge(context['amount']) * 100)
     new_payment = {
-        'amount': int(context['amount'] * 100),
+        'amount': amount_pence,
+        'service_charge': service_charge_pence,
         'recipient_name': context['prisoner_name'],
         'prisoner_number': context['prisoner_number'],
         'prisoner_dob': context['prisoner_dob'].isoformat(),
@@ -181,7 +184,7 @@ def debit_card_view(request, context):
         payment_ref = api_response['uuid']
 
         new_govuk_payment = {
-            'amount': int(context['amount'] * 100),
+            'amount': amount_pence + service_charge_pence,
             'reference': payment_ref,
             'description': _('Payment to prisoner %(prisoner_number)s'
                              % {'prisoner_number': context['prisoner_number']}),


### PR DESCRIPTION
The GOV.UK service needs to include the service charge in the
total payment, and there should also be a record of it in our
data.