### PR TITLE
Align the currency symbol with the text input

### DIFF
--- a/mtp_send_money/assets-src/stylesheets/app.scss
+++ b/mtp_send_money/assets-src/stylesheets/app.scss
@@ -44,21 +44,20 @@ form .form-group .form-hint {
 
     .money-box {
       * {
-        height: 40px;
+        height: 34px;
         display: inline-block;
         vertical-align: bottom;
       }
-      div.form-control {
-        width: 2em;
-        min-width: 2em;
-        border-right: 0;
-        line-height: 1;
-        background-color: $panel-colour;
-        text-align: center;
-        font-size: 120%;
+      .mtp-currency-sign {
+        background-color: $highlight-colour;
         font-weight: 900;
+        min-width: 1.8em;
+        width: 1.8em;
+        text-align: center;
+        border-right: 0;
+        color: $text-colour;
       }
-      input {
+      .mtp-charges-amount {
         width: 5em;
       }
     }

--- a/mtp_send_money/templates/send_money/send-money.html
+++ b/mtp_send_money/templates/send_money/send-money.html
@@ -79,14 +79,15 @@
              <div class="error-message">{{ error }}</div>
            {% endfor %}
            <div class="money-box">
-             <div class="form-control">£</div><input id="{{ field.id_for_label }}"
-                                                     class="form-control mtp-charges-amount"
-                                                     maxlength="10"
-                                                     name="{{ field.html_name }}"
-                                                     value="{{ field.value|default:'' }}"
-                                                     type="text"
-                                                     data-percentage-charge="{{ service_charge_percentage }}"
-                                                     data-fixed-charge="{{ service_charge_fixed }}" />
+             <input class="form-control mtp-currency-sign" type="text" value="£"
+                    disabled=""/><input id="{{ field.id_for_label }}"
+                                        class="form-control mtp-charges-amount"
+                                        maxlength="10"
+                                        name="{{ field.html_name }}"
+                                        value="{{ field.value|default:'' }}"
+                                        type="text"
+                                        data-percentage-charge="{{ service_charge_percentage }}"
+                                        data-fixed-charge="{{ service_charge_fixed }}" />
            </div>
           </div>
         </fieldset>


### PR DESCRIPTION
- No other way than make the currency symbol an input too for perfect alignment
- IE8 prevents making the pound sign black so it's gray - acceptable