### PR TITLE
Add feedback tag when coming from citizen info page

### DIFF
--- a/mtp_send_money/apps/feedback/forms.py
+++ b/mtp_send_money/apps/feedback/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from zendesk_tickets.forms import BaseTicketForm
 
@@ -17,5 +18,7 @@ class CitizenFeedbackForm(BaseTicketForm):
         extra_context = dict(extra_context, **{
             'user_agent': request.META.get('HTTP_USER_AGENT')
         })
+        if self.referer and settings.CITIZEN_INFO_URL in self.referer:
+            tags.append('citizen-info')
         return super().submit_ticket(request, subject, tags,
                                      ticket_template_name, extra_context)

--- a/mtp_send_money/settings/base.py
+++ b/mtp_send_money/settings/base.py
@@ -230,6 +230,8 @@ ZENDESK_CUSTOM_FIELDS = {
     'contact_email': 30769508
 }
 
+CITIZEN_INFO_URL = 'sendmoneytoaprisoner.service.justice.gov.uk'
+
 # TODO: remove option once TD allows showing bank transfers
 HIDE_BANK_TRANSFER_OPTION = True
 


### PR DESCRIPTION
This is to differentiate, in future, from debit card payments.