### PR TITLE
Disable functional incompatible functional tests against remote service

### DIFF
--- a/mtp_send_money/apps/send_money/tests/test_functional.py
+++ b/mtp_send_money/apps/send_money/tests/test_functional.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import unittest
 from unittest import mock
 
@@ -142,6 +143,7 @@ class SendMoneyFeedbackPages(SendMoneyFunctionalTestCase):
         self.assertInSource('<h1>Thank you for your feedback</h1>')
 
 
+@unittest.skipIf('DJANGO_TEST_REMOTE_INTEGRATION_URL' in os.environ, 'test only runs locally')
 @override_settings(GOVUK_PAY_URL='http://payment.gov.uk',
                    GOVUK_PAY_AUTH_TOKEN='15a21a56-817a-43d4-bf8d-f01f298298e8')
 class SendMoneyConfirmationPage(SendMoneyFunctionalTestCase):

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-utils[testing]==0.7
+money-to-prisoners-utils[testing]==0.8


### PR DESCRIPTION
Some functional test rely on mocks which require the server to be
running locally, and thus do not function when run against a deployed
environment.