### PR TITLE
Add a flow solely for bank transfer instructions and reference generation

### DIFF
--- a/mtp_send_money/apps/send_money/forms.py
+++ b/mtp_send_money/apps/send_money/forms.py
@@ -15,11 +15,7 @@ from send_money.utils import (
 )
 
 
-class SendMoneyForm(GARequestErrorReportingMixin, forms.Form):
-    prisoner_name = forms.CharField(
-        label=_('Prisoner name'),
-        max_length=250,
-    )
+class PrisonerDetailsForm(GARequestErrorReportingMixin, forms.Form):
     prisoner_number = forms.CharField(
         label=_('Prisoner number'),
         max_length=7,
@@ -28,36 +24,41 @@ class SendMoneyForm(GARequestErrorReportingMixin, forms.Form):
     prisoner_dob = SplitDateField(
         label=_('Prisoner date of birth'),
     )
-    amount = forms.DecimalField(
-        label=_('Amount you are sending'),
-        min_value=decimal.Decimal('0.01'),
-        max_value=decimal.Decimal('1000000'),
-        decimal_places=2,
-    )
-    payment_method = forms.ChoiceField(
-        label=_('Payment method'),
-        widget=forms.RadioSelect,
-        choices=PaymentMethod.django_choices(),
-        initial=PaymentMethod.debit_card,
-    )
 
     @classmethod
     def get_field_names(cls):
         return [field for field in cls.base_fields]
 
+    @classmethod
+    def session_contains_form_data(cls, session):
+        for required_key in cls.get_field_names():
+            if not session.get(required_key):
+                return False
+        return True
+
     def __init__(self, request, **kwargs):
         self.request = request
         super().__init__(**kwargs)
-
-    def switch_to_hidden(self):
-        for field in self.fields.values():
-            field.widget = field.hidden_widget()
 
     def clean_prisoner_number(self):
         prisoner_number = self.cleaned_data.get('prisoner_number')
         if prisoner_number:
             prisoner_number = prisoner_number.upper()
         return prisoner_number
+
+    def check_prisoner_validity(self, prisoner_number, prisoner_dob):
+        prisoner_dob = serialise_date(prisoner_dob)
+        client = get_api_client()
+        try:
+            prisoners = client.prisoner_validity().get(prisoner_number=prisoner_number,
+                                                       prisoner_dob=prisoner_dob)
+            assert prisoners['count'] == 1
+            prisoner = prisoners['results'][0]
+            return prisoner and prisoner['prisoner_number'] == prisoner_number \
+                and prisoner['prisoner_dob'] == prisoner_dob
+        except (HttpNotFoundError, KeyError, IndexError, AssertionError):
+            pass
+        return False
 
     def clean(self):
         prisoner_number = self.cleaned_data.get('prisoner_number')
@@ -77,19 +78,32 @@ class SendMoneyForm(GARequestErrorReportingMixin, forms.Form):
                 code='connection')
         return self.cleaned_data
 
-    def check_prisoner_validity(self, prisoner_number, prisoner_dob):
-        prisoner_dob = serialise_date(prisoner_dob)
-        client = get_api_client()
-        try:
-            prisoners = client.prisoner_validity().get(prisoner_number=prisoner_number,
-                                                       prisoner_dob=prisoner_dob)
-            assert prisoners['count'] == 1
-            prisoner = prisoners['results'][0]
-            return prisoner and prisoner['prisoner_number'] == prisoner_number \
-                and prisoner['prisoner_dob'] == prisoner_dob
-        except (HttpNotFoundError, KeyError, IndexError, AssertionError):
-            pass
-        return False
+    def save_form_data_in_session(self, session):
+        session['prisoner_dob'] = serialise_date(self.cleaned_data['prisoner_dob'])
+        session['prisoner_number'] = self.cleaned_data['prisoner_number']
+
+
+class SendMoneyForm(PrisonerDetailsForm):
+    prisoner_name = forms.CharField(
+        label=_('Prisoner name'),
+        max_length=250,
+    )
+    amount = forms.DecimalField(
+        label=_('Amount you are sending'),
+        min_value=decimal.Decimal('0.01'),
+        max_value=decimal.Decimal('1000000'),
+        decimal_places=2,
+    )
+    payment_method = forms.ChoiceField(
+        label=_('Payment method'),
+        widget=forms.RadioSelect,
+        choices=PaymentMethod.django_choices(),
+        initial=PaymentMethod.debit_card,
+    )
+
+    def switch_to_hidden(self):
+        for field in self.fields.values():
+            field.widget = field.hidden_widget()
 
     def save_form_data_in_session(self, session):
         form_data = self.cleaned_data
@@ -97,13 +111,6 @@ class SendMoneyForm(GARequestErrorReportingMixin, forms.Form):
             session[field] = form_data[field]
         session['prisoner_dob'] = serialise_date(session['prisoner_dob'])
         session['amount'] = serialise_amount(session['amount'])
-
-    @classmethod
-    def session_contains_form_data(cls, session):
-        for required_key in SendMoneyForm.get_field_names():
-            if not session.get(required_key):
-                return False
-        return True
 
     @classmethod
     def form_data_from_session(cls, session):

--- a/mtp_send_money/apps/send_money/tests/__init__.py
+++ b/mtp_send_money/apps/send_money/tests/__init__.py
@@ -1,3 +1,9 @@
+from contextlib import contextmanager
+from importlib import reload
+import sys
+
+from django.conf import settings
+from django.core.urlresolvers import clear_url_caches, set_urlconf
 from django.utils.crypto import get_random_string
 from moj_auth.api_client import REQUEST_TOKEN_URL
 
@@ -35,3 +41,21 @@ def split_prisoner_dob_for_post(data):
     except (KeyError, ValueError):
         return data
     return new_data
+
+
+@contextmanager
+def reload_payment_urls(test_case, show_bank_transfer=False, show_debit_card=False):
+    def reload_urls():
+        try:
+            reload(sys.modules['send_money.urls'])
+            reload(sys.modules[settings.ROOT_URLCONF])
+        except KeyError:
+            pass
+        clear_url_caches()
+        set_urlconf(None)
+
+    with test_case.settings(SHOW_BANK_TRANSFER_OPTION=show_bank_transfer,
+                            SHOW_DEBIT_CARD_OPTION=show_debit_card):
+        reload_urls()
+        yield
+    reload_urls()

--- a/mtp_send_money/apps/send_money/tests/test_views.py
+++ b/mtp_send_money/apps/send_money/tests/test_views.py
@@ -1,14 +1,10 @@
 import datetime
-from contextlib import contextmanager
 from decimal import Decimal
-from importlib import reload
 import json
-import sys
-import unittest
 from unittest import mock
 
 from django.conf import settings
-from django.core.urlresolvers import reverse, clear_url_caches, set_urlconf
+from django.core.urlresolvers import reverse_lazy
 from django.test.testcases import SimpleTestCase
 from django.test.utils import override_settings
 from django.utils.html import escape
@@ -18,6 +14,7 @@ import responses
 from send_money.forms import PaymentMethod, SendMoneyForm
 from send_money.tests import mock_auth, split_prisoner_dob_for_post
 from send_money.utils import govuk_url, api_url
+from . import reload_payment_urls
 
 SAMPLE_FORM = {
     'prisoner_name': 'John Smith',
@@ -29,8 +26,14 @@ SAMPLE_FORM = {
 
 
 class BaseTestCase(SimpleTestCase):
-    send_money_url = reverse('send_money:send_money')
-    check_details_url = reverse('send_money:check_details')
+
+    @property
+    def send_money_url(self):
+        return reverse_lazy('send_money:send_money')
+
+    @property
+    def check_details_url(self):
+        return reverse_lazy('send_money:check_details')
 
     def assertOnPage(self, response, url_name):  # noqa
         self.assertContains(response, '<!-- %s -->' % url_name)
@@ -82,376 +85,409 @@ class SendMoneyViewTestCase(BaseTestCase):
     url = BaseTestCase.send_money_url
 
     def test_send_money_page_loads(self):
-        response = self.client.get(self.url)
-        self.assertOnPage(response, 'send_money')
+        with reload_payment_urls(self, show_debit_card=True):
+            response = self.client.get(self.url)
+            self.assertOnPage(response, 'send_money')
 
     @override_settings(SERVICE_CHARGE_PERCENTAGE=Decimal('2.5'),
                        SERVICE_CHARGE_FIXED=Decimal('0.21'))
     def test_send_money_page_shows_service_charge(self):
-        response = self.client.get(self.url)
-        self.assertContains(response, '2.5%')
-        self.assertContains(response, '21p')
+        with reload_payment_urls(self, show_debit_card=True):
+            response = self.client.get(self.url)
+            self.assertContains(response, '2.5%')
+            self.assertContains(response, '21p')
 
     @override_settings(SERVICE_CHARGED=False)
     def test_send_money_page_shows_no_service_charge(self):
-        response = self.client.get(self.url)
-        self.assertNotContains(response, 'service charge')
+        with reload_payment_urls(self, show_debit_card=True):
+            response = self.client.get(self.url)
+            self.assertNotContains(response, 'service charge')
 
     @mock.patch('send_money.utils.api_client')
     def test_send_money_page_previews_form(self, mocked_api_client):
-        response = self.submit_send_money_form(mocked_api_client, follow=True)
-        self.assertOnPage(response, 'check_details')
+        with reload_payment_urls(self, show_debit_card=True):
+            response = self.submit_send_money_form(mocked_api_client, follow=True)
+            self.assertOnPage(response, 'check_details')
 
-    @mock.patch('send_money.forms.SendMoneyForm.check_prisoner_validity')
+    @mock.patch('send_money.forms.PrisonerDetailsForm.check_prisoner_validity')
     def test_send_money_page_displays_errors_for_invalid_prisoner_number(self, mocked_check_prisoner_validity):
-        response = self.client.post(self.url, data=split_prisoner_dob_for_post({
-            'prisoner_name': 'John Smith',
-            'prisoner_number': 'a1231a1',
-            'prisoner_dob': '1980-10-04',
-            'amount': '10.00',
-            'payment_method': PaymentMethod.debit_card,
-        }))
-        self.assertContains(response, 'Incorrect prisoner number format')
-        form = response.context['form']
-        self.assertTrue(form.errors)
-        self.assertEqual(mocked_check_prisoner_validity.call_count, 0)
+        with reload_payment_urls(self, show_debit_card=True):
+            response = self.client.post(self.url, data=split_prisoner_dob_for_post({
+                'prisoner_name': 'John Smith',
+                'prisoner_number': 'a1231a1',
+                'prisoner_dob': '1980-10-04',
+                'amount': '10.00',
+                'payment_method': PaymentMethod.debit_card,
+            }))
+            self.assertContains(response, 'Incorrect prisoner number format')
+            form = response.context['form']
+            self.assertTrue(form.errors)
+            self.assertEqual(mocked_check_prisoner_validity.call_count, 0)
 
-    @mock.patch('send_money.forms.SendMoneyForm.check_prisoner_validity')
+    @mock.patch('send_money.forms.PrisonerDetailsForm.check_prisoner_validity')
     def test_send_money_page_displays_errors_for_invalid_prisoner_dob(self, mocked_check_prisoner_validity):
-        response = self.client.post(self.url, data={
-            'prisoner_name': 'John Smith',
-            'prisoner_number': 'A1231DE',
-            'amount': '10.00',
-            'payment_method': PaymentMethod.debit_card,
-        })
-        self.assertContains(response, 'This field is required')
-        form = response.context['form']
-        self.assertTrue(form.errors)
-        self.assertEqual(mocked_check_prisoner_validity.call_count, 0)
+        with reload_payment_urls(self, show_debit_card=True):
+            response = self.client.post(self.url, data={
+                'prisoner_name': 'John Smith',
+                'prisoner_number': 'A1231DE',
+                'amount': '10.00',
+                'payment_method': PaymentMethod.debit_card,
+            })
+            self.assertContains(response, 'This field is required')
+            form = response.context['form']
+            self.assertTrue(form.errors)
+            self.assertEqual(mocked_check_prisoner_validity.call_count, 0)
 
-    @mock.patch('send_money.forms.SendMoneyForm.check_prisoner_validity')
+    @mock.patch('send_money.forms.PrisonerDetailsForm.check_prisoner_validity')
     def test_send_money_page_displays_errors_for_invalid_prisoner_details(self, mocked_check_prisoner_validity):
         mocked_check_prisoner_validity.return_value = False
-        response = self.client.post(self.url, data=split_prisoner_dob_for_post({
-            'prisoner_name': 'John Smith',
-            'prisoner_number': 'A1231DE',
-            'prisoner_dob': '1980-10-04',
-            'amount': '10.00',
-            'payment_method': PaymentMethod.debit_card,
-        }))
-        self.assertContains(response, escape("No prisoner matches the details you’ve supplied."))
-        form = response.context['form']
-        self.assertTrue(form.errors)
+        with reload_payment_urls(self, show_debit_card=True):
+            response = self.client.post(self.url, data=split_prisoner_dob_for_post({
+                'prisoner_name': 'John Smith',
+                'prisoner_number': 'A1231DE',
+                'prisoner_dob': '1980-10-04',
+                'amount': '10.00',
+                'payment_method': PaymentMethod.debit_card,
+            }))
+            self.assertContains(response, escape("No prisoner matches the details you’ve supplied."))
+            form = response.context['form']
+            self.assertTrue(form.errors)
 
-    @mock.patch('send_money.forms.SendMoneyForm.check_prisoner_validity')
+    @mock.patch('send_money.forms.PrisonerDetailsForm.check_prisoner_validity')
     def test_send_money_page_displays_errors_for_dropped_api_connection(self, mocked_check_prisoner_validity):
         mocked_check_prisoner_validity.side_effect = ConnectionError
-        response = self.client.post(self.url, data=split_prisoner_dob_for_post({
-            'prisoner_name': 'John Smith',
-            'prisoner_number': 'A1231DE',
-            'prisoner_dob': '1980-10-04',
-            'amount': '10.00',
-            'payment_method': PaymentMethod.debit_card,
-        }))
-        self.assertContains(response, 'Could not connect to the service.')
-        form = response.context['form']
-        self.assertTrue(form.errors)
+        with reload_payment_urls(self, show_debit_card=True):
+            response = self.client.post(self.url, data=split_prisoner_dob_for_post({
+                'prisoner_name': 'John Smith',
+                'prisoner_number': 'A1231DE',
+                'prisoner_dob': '1980-10-04',
+                'amount': '10.00',
+                'payment_method': PaymentMethod.debit_card,
+            }))
+            self.assertContains(response, 'Could not connect to the service.')
+            form = response.context['form']
+            self.assertTrue(form.errors)
 
     @mock.patch('send_money.utils.api_client')
     def test_send_money_page_allows_changing_form(self, mocked_api_client):
-        response = self.submit_send_money_form(mocked_api_client, follow=True)
-        self.assertOnPage(response, 'check_details')
-        response = self.client.get(self.send_money_url + '?change')
-        self.assertOnPage(response, 'send_money')
-        self.assertContains(response, '"John Smith"')
-        self.assertContains(response, '"A1231DE"')
-        self.assertContains(response, '"4"')
-        self.assertContains(response, '"10"')
-        self.assertContains(response, '"1980"')
-        self.assertContains(response, '"10.00"')
+        with reload_payment_urls(self, show_debit_card=True):
+            response = self.submit_send_money_form(mocked_api_client, follow=True)
+            self.assertOnPage(response, 'check_details')
+            response = self.client.get(self.send_money_url + '?change')
+            self.assertOnPage(response, 'send_money')
+            self.assertContains(response, '"John Smith"')
+            self.assertContains(response, '"A1231DE"')
+            self.assertContains(response, '"4"')
+            self.assertContains(response, '"10"')
+            self.assertContains(response, '"1980"')
+            self.assertContains(response, '"10.00"')
 
     @mock.patch('send_money.utils.api_client')
     def test_send_money_page_can_proceed_to_debit_card(self, mocked_api_client):
-        response = self.submit_send_money_form(mocked_api_client, follow=True)
-        self.assertOnPage(response, 'check_details')
-        response = self.submit_check_details_form(mocked_api_client, update_data={
-            'next': '',
-        })
-        self.assertRedirects(response, reverse('send_money:debit_card'),
-                             fetch_redirect_response=False)
+        with reload_payment_urls(self, show_debit_card=True):
+            response = self.submit_send_money_form(mocked_api_client, follow=True)
+            self.assertOnPage(response, 'check_details')
+            response = self.submit_check_details_form(mocked_api_client, update_data={
+                'next': '',
+            })
+            self.assertRedirects(response, reverse_lazy('send_money:debit_card'),
+                                 fetch_redirect_response=False)
 
     @mock.patch('send_money.utils.api_client')
     def test_send_money_page_can_proceed_to_bank_transfer(self, mocked_api_client):
-        response = self.submit_send_money_form(mocked_api_client, update_data={
-            'payment_method': PaymentMethod.bank_transfer,
-        }, follow=True)
-        self.assertOnPage(response, 'check_details')
-        response = self.submit_check_details_form(mocked_api_client, update_data={
-            'payment_method': PaymentMethod.bank_transfer,
-            'next': '',
-        })
-        self.assertRedirects(response, reverse('send_money:bank_transfer'),
-                             fetch_redirect_response=False)
+        with reload_payment_urls(self, show_bank_transfer=True, show_debit_card=True):
+            response = self.submit_send_money_form(mocked_api_client, update_data={
+                'payment_method': PaymentMethod.bank_transfer,
+            }, follow=True)
+            self.assertOnPage(response, 'check_details')
+            response = self.submit_check_details_form(mocked_api_client, update_data={
+                'payment_method': PaymentMethod.bank_transfer,
+                'next': '',
+            })
+            self.assertRedirects(response, reverse_lazy('send_money:bank_transfer'),
+                                 fetch_redirect_response=False)
 
 
-@unittest.skipIf(settings.HIDE_BANK_TRANSFER_OPTION, 'bank transfer is disabled')
 class BankTransferViewTestCase(BaseTestCase):
-    url = reverse('send_money:bank_transfer')
+    url = reverse_lazy('send_money:bank_transfer')
 
     def bank_transfer_flow(self, mocked_api_client):
-        response = self.submit_send_money_form(mocked_api_client, update_data={
-            'payment_method': PaymentMethod.bank_transfer,
-        }, follow=True)
-        self.assertOnPage(response, 'check_details')
-        response = self.submit_check_details_form(mocked_api_client, update_data={
-            'payment_method': PaymentMethod.bank_transfer,
-            'next': '',
-        }, follow=True)
-        self.assertOnPage(response, 'bank_transfer')
-        return response
+        with reload_payment_urls(self, show_bank_transfer=True, show_debit_card=True):
+            response = self.submit_send_money_form(mocked_api_client, update_data={
+                'payment_method': PaymentMethod.bank_transfer,
+            }, follow=True)
+            self.assertOnPage(response, 'check_details')
+            response = self.submit_check_details_form(mocked_api_client, update_data={
+                'payment_method': PaymentMethod.bank_transfer,
+                'next': '',
+            }, follow=True)
+            self.assertOnPage(response, 'bank_transfer')
+            return response
 
     def test_bank_transfer_page_not_directly_accessible(self):
-        self.assertPageNotDirectlyAccessible()
+        with reload_payment_urls(self, show_bank_transfer=True, show_debit_card=True):
+            self.assertPageNotDirectlyAccessible()
 
     @mock.patch('send_money.utils.api_client')
     def test_bank_transfer_page_renders_prisoner_reference(self, mocked_api_client):
-        response = self.bank_transfer_flow(mocked_api_client)
-        bank_transfer_reference = 'A1231DE 04/10/1980'
-        self.assertContains(response, bank_transfer_reference)
-        self.assertEqual(response.context['bank_transfer_reference'],
-                         bank_transfer_reference)
+        with reload_payment_urls(self, show_bank_transfer=True, show_debit_card=True):
+            response = self.bank_transfer_flow(mocked_api_client)
+            bank_transfer_reference = 'A1231DE 04/10/1980'
+            self.assertContains(response, bank_transfer_reference)
+            self.assertEqual(response.context['bank_transfer_reference'],
+                             bank_transfer_reference)
 
     @mock.patch('send_money.utils.api_client')
     def test_bank_transfer_page_renders_noms_account_details(self, mocked_api_client):
-        response = self.bank_transfer_flow(mocked_api_client)
-        keys = ['payable_to', 'account_number', 'sort_code']
-        for key in keys:
-            value = response.context[key]
-            self.assertTrue(value)
-            self.assertContains(response, value)
+        with reload_payment_urls(self, show_bank_transfer=True, show_debit_card=True):
+            response = self.bank_transfer_flow(mocked_api_client)
+            keys = ['account_number', 'sort_code']
+            for key in keys:
+                value = response.context[key]
+                self.assertTrue(value)
+                self.assertContains(response, value)
 
     @mock.patch('send_money.utils.api_client')
     def test_bank_transfer_page_clears_session(self, mocked_api_client):
-        self.bank_transfer_flow(mocked_api_client)
-        for key in SendMoneyForm.get_field_names():
-            self.assertNotIn(key, self.client.session)
+        with reload_payment_urls(self, show_bank_transfer=True, show_debit_card=True):
+            self.bank_transfer_flow(mocked_api_client)
+            for key in SendMoneyForm.get_field_names():
+                self.assertNotIn(key, self.client.session)
+
+
+class BankTransferOnlyTestCase(BankTransferViewTestCase):
+
+    def bank_transfer_flow(self, mocked_api_client):
+        with reload_payment_urls(self, show_bank_transfer=True):
+            return self.submit_send_money_form(
+                mocked_api_client, replace_data={
+                    'prisoner_number': SAMPLE_FORM['prisoner_number'],
+                    'prisoner_dob': SAMPLE_FORM['prisoner_dob'],
+                }, follow=True
+            )
 
 
 class DebitCardViewTestCase(BaseTestCase):
-    url = reverse('send_money:debit_card')
+    url = reverse_lazy('send_money:debit_card')
     payment_process_path = '/take'
 
     def test_debit_card_page_not_directly_accessible(self):
-        self.assertPageNotDirectlyAccessible()
+        with reload_payment_urls(self, show_debit_card=True):
+            self.assertPageNotDirectlyAccessible()
 
     def test_debit_card_payment(self):
-        self.populate_session()
-        with responses.RequestsMock() as rsps, self.settings(GOVUK_PAY_URL='http://payment.gov.uk'):
-            ref = 'wargle-blargle'
-            processor_id = '3'
-            mock_auth(rsps)
-            rsps.add(
-                rsps.POST,
-                api_url('/payments/'),
-                json={'uuid': ref},
-                status=201,
-            )
-            rsps.add(
-                rsps.POST,
-                govuk_url('/payments/'),
-                json={
-                    'payment_id': processor_id,
-                    '_links': {
-                        'next_url': {
-                            'method': 'GET',
-                            'href': govuk_url(self.payment_process_path),
+        with reload_payment_urls(self, show_debit_card=True):
+            self.populate_session()
+            with responses.RequestsMock() as rsps, self.settings(GOVUK_PAY_URL='http://payment.gov.uk'):
+                ref = 'wargle-blargle'
+                processor_id = '3'
+                mock_auth(rsps)
+                rsps.add(
+                    rsps.POST,
+                    api_url('/payments/'),
+                    json={'uuid': ref},
+                    status=201,
+                )
+                rsps.add(
+                    rsps.POST,
+                    govuk_url('/payments/'),
+                    json={
+                        'payment_id': processor_id,
+                        '_links': {
+                            'next_url': {
+                                'method': 'GET',
+                                'href': govuk_url(self.payment_process_path),
+                            }
                         }
-                    }
-                },
-                status=201
-            )
-            rsps.add(
-                rsps.PATCH,
-                api_url('/payments/%s/' % ref),
-                status=200,
-            )
-            response = self.client.get(self.url, follow=False)
+                    },
+                    status=201
+                )
+                rsps.add(
+                    rsps.PATCH,
+                    api_url('/payments/%s/' % ref),
+                    status=200,
+                )
+                response = self.client.get(self.url, follow=False)
 
-            # check amount and service charge submitted to api
-            self.assertEqual(json.loads(rsps.calls[1].request.body)['amount'], 1000)
-            self.assertEqual(json.loads(rsps.calls[1].request.body)['service_charge'], 44)
-            # check total charge submitted to govuk
-            self.assertEqual(json.loads(rsps.calls[2].request.body)['amount'], 1044)
+                # check amount and service charge submitted to api
+                self.assertEqual(json.loads(rsps.calls[1].request.body)['amount'], 1000)
+                self.assertEqual(json.loads(rsps.calls[1].request.body)['service_charge'], 44)
+                # check total charge submitted to govuk
+                self.assertEqual(json.loads(rsps.calls[2].request.body)['amount'], 1044)
 
-            self.assertRedirects(
-                response, govuk_url(self.payment_process_path),
-                fetch_redirect_response=False
-            )
+                self.assertRedirects(
+                    response, govuk_url(self.payment_process_path),
+                    fetch_redirect_response=False
+                )
 
     def test_debit_card_payment_handles_api_errors(self):
-        self.populate_session()
-        with responses.RequestsMock() as rsps, self.settings(GOVUK_PAY_URL='http://payment.gov.uk'):
-            mock_auth(rsps)
-            rsps.add(
-                rsps.POST,
-                api_url('/payments/'),
-                status=500,
-            )
-            response = self.client.get(self.url, follow=False)
-            self.assertContains(response, 'Sorry, we are unable to take your payment.')
+        with reload_payment_urls(self, show_debit_card=True):
+            self.populate_session()
+            with responses.RequestsMock() as rsps, self.settings(GOVUK_PAY_URL='http://payment.gov.uk'):
+                mock_auth(rsps)
+                rsps.add(
+                    rsps.POST,
+                    api_url('/payments/'),
+                    status=500,
+                )
+                response = self.client.get(self.url, follow=False)
+                self.assertContains(response, 'Sorry, we are unable to take your payment.')
 
     def test_debit_card_payment_handles_govuk_errors(self):
-        self.populate_session()
-        with responses.RequestsMock() as rsps, self.settings(GOVUK_PAY_URL='http://payment.gov.uk'):
-            mock_auth(rsps)
-            rsps.add(
-                rsps.POST,
-                api_url('/payments/'),
-                json={'uuid': 'wargle-blargle'},
-                status=201,
-            )
-            rsps.add(
-                rsps.POST,
-                govuk_url('/payments/'),
-                status=500
-            )
-            response = self.client.get(self.url, follow=False)
-            self.assertContains(response, 'Sorry, we are unable to take your payment.')
+        with reload_payment_urls(self, show_debit_card=True):
+            self.populate_session()
+            with responses.RequestsMock() as rsps, self.settings(GOVUK_PAY_URL='http://payment.gov.uk'):
+                mock_auth(rsps)
+                rsps.add(
+                    rsps.POST,
+                    api_url('/payments/'),
+                    json={'uuid': 'wargle-blargle'},
+                    status=201,
+                )
+                rsps.add(
+                    rsps.POST,
+                    govuk_url('/payments/'),
+                    status=500
+                )
+                response = self.client.get(self.url, follow=False)
+                self.assertContains(response, 'Sorry, we are unable to take your payment.')
 
 
 class ConfirmationViewTestCase(BaseTestCase):
-    url = reverse('send_money:confirmation')
+    url = reverse_lazy('send_money:confirmation')
 
     def test_confirmation_redirects_if_no_reference_param(self):
-        response = self.client.get(self.url, follow=False)
-        self.assertRedirects(response, self.send_money_url)
+        with reload_payment_urls(self, show_debit_card=True):
+            response = self.client.get(self.url, follow=False)
+            self.assertRedirects(response, self.send_money_url)
 
     def test_confirmation(self):
-        self.populate_session()
-        with responses.RequestsMock() as rsps, self.settings(GOVUK_PAY_URL='http://payment.gov.uk'):
-            ref = 'wargle-blargle'
-            processor_id = '3'
-            mock_auth(rsps)
-            rsps.add(
-                rsps.GET,
-                api_url('/payments/%s/' % ref),
-                json={
-                    'processor_id': processor_id,
-                    'recipient_name': 'John',
-                    'amount': 1000,
-                    'created': datetime.datetime.now().isoformat() + 'Z',
-                },
-                status=200,
-            )
-            rsps.add(
-                rsps.GET,
-                govuk_url('/payments/%s/' % processor_id),
-                json={
-                    'status': 'SUCCEEDED'
-                },
-                status=200
-            )
-            rsps.add(
-                rsps.PATCH,
-                api_url('/payments/%s/' % ref),
-                status=200,
-            )
-            response = self.client.get(
-                self.url, {'payment_ref': ref}, follow=False
-            )
-            self.assertContains(response, 'success')
-            # check session is cleared
-            self.assertEqual(None, self.client.session.get('prisoner_number'))
-            self.assertEqual(None, self.client.session.get('amount'))
+        with reload_payment_urls(self, show_debit_card=True):
+            self.populate_session()
+            with responses.RequestsMock() as rsps, self.settings(GOVUK_PAY_URL='http://payment.gov.uk'):
+                ref = 'wargle-blargle'
+                processor_id = '3'
+                mock_auth(rsps)
+                rsps.add(
+                    rsps.GET,
+                    api_url('/payments/%s/' % ref),
+                    json={
+                        'processor_id': processor_id,
+                        'recipient_name': 'John',
+                        'amount': 1000,
+                        'created': datetime.datetime.now().isoformat() + 'Z',
+                    },
+                    status=200,
+                )
+                rsps.add(
+                    rsps.GET,
+                    govuk_url('/payments/%s/' % processor_id),
+                    json={
+                        'status': 'SUCCEEDED'
+                    },
+                    status=200
+                )
+                rsps.add(
+                    rsps.PATCH,
+                    api_url('/payments/%s/' % ref),
+                    status=200,
+                )
+                response = self.client.get(
+                    self.url, {'payment_ref': ref}, follow=False
+                )
+                self.assertContains(response, 'success')
+                # check session is cleared
+                self.assertEqual(None, self.client.session.get('prisoner_number'))
+                self.assertEqual(None, self.client.session.get('amount'))
 
     def test_confirmation_handles_api_errors(self):
-        with responses.RequestsMock() as rsps, self.settings(GOVUK_PAY_URL='http://payment.gov.uk'):
-            ref = 'wargle-blargle'
-            processor_id = '3'
-            mock_auth(rsps)
-            rsps.add(
-                rsps.GET,
-                api_url('/payments/%s/' % ref),
-                json={
-                    'processor_id': processor_id,
-                    'recipient_name': 'John',
-                    'amount': 1000,
-                    'created': datetime.datetime.now().isoformat() + 'Z',
-                },
-                status=200,
-            )
-            rsps.add(
-                rsps.GET,
-                govuk_url('/payments/%s/' % processor_id),
-                json={
-                    'status': 'SUCCEEDED'
-                },
-                status=200
-            )
-            rsps.add(
-                rsps.PATCH,
-                api_url('/payments/%s/' % ref),
-                status=500,
-            )
-            response = self.client.get(
-                self.url, {'payment_ref': ref}, follow=False
-            )
-            self.assertContains(response, 'your payment could not be processed')
+        with reload_payment_urls(self, show_debit_card=True):
+            with responses.RequestsMock() as rsps, self.settings(GOVUK_PAY_URL='http://payment.gov.uk'):
+                ref = 'wargle-blargle'
+                processor_id = '3'
+                mock_auth(rsps)
+                rsps.add(
+                    rsps.GET,
+                    api_url('/payments/%s/' % ref),
+                    json={
+                        'processor_id': processor_id,
+                        'recipient_name': 'John',
+                        'amount': 1000,
+                        'created': datetime.datetime.now().isoformat() + 'Z',
+                    },
+                    status=200,
+                )
+                rsps.add(
+                    rsps.GET,
+                    govuk_url('/payments/%s/' % processor_id),
+                    json={
+                        'status': 'SUCCEEDED'
+                    },
+                    status=200
+                )
+                rsps.add(
+                    rsps.PATCH,
+                    api_url('/payments/%s/' % ref),
+                    status=500,
+                )
+                response = self.client.get(
+                    self.url, {'payment_ref': ref}, follow=False
+                )
+                self.assertContains(response, 'your payment could not be processed')
 
     def test_confirmation_handles_govuk_errors(self):
-        with responses.RequestsMock() as rsps, self.settings(GOVUK_PAY_URL='http://payment.gov.uk'):
-            ref = 'wargle-blargle'
-            processor_id = '3'
-            mock_auth(rsps)
-            rsps.add(
-                rsps.GET,
-                api_url('/payments/%s/' % ref),
-                json={
-                    'processor_id': processor_id,
-                    'recipient_name': 'John',
-                    'amount': 1000,
-                    'created': datetime.datetime.now().isoformat() + 'Z',
-                },
-                status=200,
-            )
-            rsps.add(
-                rsps.GET,
-                govuk_url('/payments/%s/' % processor_id),
-                status=500
-            )
-            response = self.client.get(
-                self.url, {'payment_ref': ref}, follow=False
-            )
-            self.assertContains(response, 'your payment could not be processed')
+        with reload_payment_urls(self, show_debit_card=True):
+            with responses.RequestsMock() as rsps, self.settings(GOVUK_PAY_URL='http://payment.gov.uk'):
+                ref = 'wargle-blargle'
+                processor_id = '3'
+                mock_auth(rsps)
+                rsps.add(
+                    rsps.GET,
+                    api_url('/payments/%s/' % ref),
+                    json={
+                        'processor_id': processor_id,
+                        'recipient_name': 'John',
+                        'amount': 1000,
+                        'created': datetime.datetime.now().isoformat() + 'Z',
+                    },
+                    status=200,
+                )
+                rsps.add(
+                    rsps.GET,
+                    govuk_url('/payments/%s/' % processor_id),
+                    status=500
+                )
+                response = self.client.get(
+                    self.url, {'payment_ref': ref}, follow=False
+                )
+                self.assertContains(response, 'your payment could not be processed')
 
 
-class HidePaymentPagesTestCase(SimpleTestCase):
-
-    @contextmanager
-    def hide_payment_pages(self):
-        def reload_urls():
-            reload(sys.modules[settings.ROOT_URLCONF])
-            clear_url_caches()
-            set_urlconf(None)
-
-        with self.settings(HIDE_PAYMENT_PAGES='True'):
-            reload_urls()
-            yield
-        reload_urls()
+class PaymentOptionAvailabilityTestCase(SimpleTestCase):
 
     def assert_url_inaccessible(self, url):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
-    def test_root_page_redirects(self):
-        with self.hide_payment_pages():
+    def test_root_page_redirects_when_no_options_enabled(self):
+        with reload_payment_urls(self):
             response = self.client.get('/')
-            self.assertRedirects(response, reverse('submit_ticket'))
+            self.assertRedirects(response, reverse_lazy('submit_ticket'))
 
-    def test_payment_pages_inaccessible(self):
-        with self.hide_payment_pages():
+    def test_payment_pages_inaccessible_when_no_options_enabled(self):
+        with reload_payment_urls(self):
             self.assert_url_inaccessible('/check-details')
             self.assert_url_inaccessible('/clear-session')
             self.assert_url_inaccessible('/bank-transfer')
             self.assert_url_inaccessible('/debit-card')
             self.assert_url_inaccessible('/confirmation')
+
+    def test_bank_transfer_form_accessible_when_enabled(self):
+        with reload_payment_urls(self, show_bank_transfer=True):
+            response = self.client.get('/')
+
+            self.assertContains(response, 'Prisoner number')
+            self.assertContains(response, 'Prisoner date of birth')
+
+            self.assertNotContains(response, 'Prisoner name')
+            self.assertNotContains(response, 'Amount')

--- a/mtp_send_money/apps/send_money/urls.py
+++ b/mtp_send_money/apps/send_money/urls.py
@@ -1,13 +1,24 @@
+from django.conf import settings
 from django.conf.urls import url
 
 from send_money import views
 
 app_name = 'send_money'
-urlpatterns = [
-    url(r'^$', views.SendMoneyView.as_view(), name='send_money'),
-    url(r'^check-details/$', views.CheckDetailsView.as_view(), name='check_details'),
-    url(r'^clear-session/$', views.clear_session_view, name='clear_session'),
-    url(r'^bank-transfer/$', views.bank_transfer_view, name='bank_transfer'),
-    url(r'^card-payment/$', views.debit_card_view, name='debit_card'),
-    url(r'^confirmation/$', views.confirmation_view, name='confirmation'),
-]
+
+if settings.SHOW_DEBIT_CARD_OPTION:
+    urlpatterns = [
+        url(r'^$', views.SendMoneyView.as_view(), name='send_money'),
+        url(r'^check-details/$', views.CheckDetailsView.as_view(), name='check_details'),
+        url(r'^clear-session/$', views.clear_session_view, name='clear_session'),
+        url(r'^card-payment/$', views.debit_card_view, name='debit_card'),
+        url(r'^confirmation/$', views.confirmation_view, name='confirmation'),
+    ]
+elif settings.SHOW_BANK_TRANSFER_OPTION:
+    urlpatterns = [
+        url(r'^$', views.SendMoneyBankTransferView.as_view(), name='send_money'),
+    ]
+
+if settings.SHOW_BANK_TRANSFER_OPTION:
+    urlpatterns += [
+        url(r'^bank-transfer/$', views.bank_transfer_view, name='bank_transfer'),
+    ]

--- a/mtp_send_money/settings/base.py
+++ b/mtp_send_money/settings/base.py
@@ -210,7 +210,6 @@ LOGOUT_URL = 'logout'
 
 OAUTHLIB_INSECURE_TRANSPORT = True
 
-NOMS_HOLDING_ACCOUNT_NAME = os.environ.get('NOMS_HOLDING_ACCOUNT_NAME', 'NOMS')
 NOMS_HOLDING_ACCOUNT_NUMBER = os.environ.get('NOMS_HOLDING_ACCOUNT_NUMBER', '########')
 NOMS_HOLDING_ACCOUNT_SORT_CODE = os.environ.get('NOMS_HOLDING_ACCOUNT_SORT_CODE', '##-##-##')
 
@@ -237,10 +236,8 @@ ZENDESK_CUSTOM_FIELDS = {
 
 CITIZEN_INFO_URL = 'sendmoneytoaprisoner.service.justice.gov.uk'
 
-# TODO: remove option once TD allows showing bank transfers
-HIDE_BANK_TRANSFER_OPTION = True
-
-HIDE_PAYMENT_PAGES = os.environ.get('HIDE_PAYMENT_PAGES', False)
+SHOW_BANK_TRANSFER_OPTION = os.environ.get('SHOW_BANK_TRANSFER_OPTION', 'True') == 'True'
+SHOW_DEBIT_CARD_OPTION = os.environ.get('SHOW_DEBIT_CARD_OPTION', 'True') == 'True'
 
 GOVUK_PAY_URL = os.environ.get('GOVUK_PAY_URL', '')
 GOVUK_PAY_AUTH_TOKEN = os.environ.get('GOVUK_PAY_AUTH_TOKEN', '')

--- a/mtp_send_money/templates/base.html
+++ b/mtp_send_money/templates/base.html
@@ -22,7 +22,7 @@
     <div class="subheader-item phase-banner">
       <div class="phase-tag phase-tag-alpha">{% trans "Alpha" %}</div>
           {% url 'submit_ticket' as ticket_url %}
-      <div class="phase-banner-message"><p>{% blocktrans %}This is a new service. If you need any help please <a href="{{ ticket_url }}">contact us</a>. This is a trial service for family and friends of prisoners at HMP Brixton only.{% endblocktrans %}</p></div>
+      <div class="phase-banner-message"><p>{% blocktrans %}This is a new service. If you need any help please <a href="{{ ticket_url }}">contact us</a>. This is a trial service for family and friends of prisoners at HMP Brixton and HMP High Down only.{% endblocktrans %}</p></div>
     </div>
   {% endblock %}
 

--- a/mtp_send_money/templates/send_money/bank-transfer-form.html
+++ b/mtp_send_money/templates/send_money/bank-transfer-form.html
@@ -1,0 +1,73 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load mtp_utils %}
+{% load send_money %}
+
+{% block content %}
+  <h1>{% trans 'Who are you sending money to?' %}</h1>
+
+  <form method="post" action=".">
+    {% csrf_token %}
+
+    {% if form.non_field_errors %}
+      <div class="error-summary" aria-labelledby="error-summary-heading" tabindex="-1" role="alert">
+        {% for error in form.non_field_errors %}
+          {% if forloop.first %}
+            <h1 class="error-summary-heading heading-medium" id="error-summary-heading">
+              {{ error }}
+            </h1>
+          {% else %}
+            {{ error }}
+          {% endif %}
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    <p>
+    <fieldset>
+      <legend class="form-label-bold">{% trans "Prisoner details" %}</legend>
+
+      {% with field=form.prisoner_dob %}
+        <div class="form-group form-date {% if field.errors %}error{% endif %}">
+          <p>{{ field.label }}</p>
+          {% for error in field.errors %}
+            <span class="error-message">{{ error }}</span>
+          {% endfor %}
+          <div class="form-hint">{% trans "eg 28 04 1996" %}</div>
+          <div>
+             <div class="form-date-day {% if field.errors %}error{% endif %}">
+               <label id="{{ field.auto_id }}_0-label" class="form-label" for="{{ field.auto_id }}_0">{% trans "Day" %}</label>
+               <input class="form-control" id="{{ field.auto_id }}_0" name="{{ field.html_name }}_0" value="{{ field.value.0|default:'' }}" type="text"  />
+             </div>
+             <div class="form-date-month {% if field.errors %}error{% endif %}">
+               <label id="{{ field.auto_id }}_1-label" class="form-label" for="{{ field.auto_id }}_1">{% trans "Month" %}</label>
+               <input class="form-control" id="{{ field.auto_id }}_1" name="{{ field.html_name }}_1" value="{{ field.value.1|default:'' }}" type="text"  />
+             </div>
+             <div class="form-date-year {% if field.errors %}error{% endif %}">
+               <label id="{{ field.auto_id }}_2-label" class="form-label" for="{{ field.auto_id }}_2">{% trans "Year" %}</label>
+               <input class="form-control" id="{{ field.auto_id }}_2" name="{{ field.html_name }}_2" value="{{ field.value.2|default:'' }}" type="text"  />
+             </div>
+          </div>
+        </div>
+      {% endwith %}
+
+      {% with field=form.prisoner_number %}
+        <div class="form-group {% if field.errors %}error{% endif %}">
+          <label id="{{ field.id_for_label }}-label" class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+          {% for error in field.errors %}
+            <span class="error-message">{{ error }}</span>
+          {% endfor %}
+          <div class="form-hint">{% trans "eg A1234BC" %}</div>
+          <div>
+          <input class="form-control mtp-prisoner-number" id="{{ field.id_for_label }}" name="{{ field.html_name }}" value="{{ field.value|default:'' }}" type="text"  />
+          </div>
+        </div>
+      {% endwith %}
+    </fieldset>
+    </p>
+
+    <p>
+      <input id="id_next_btn" class="button" type="submit" value="{% trans 'Continue' %}">
+    </p>
+  </form>
+{% endblock %}

--- a/mtp_send_money/templates/send_money/bank-transfer.html
+++ b/mtp_send_money/templates/send_money/bank-transfer.html
@@ -6,19 +6,32 @@
   <h1>{% trans 'Send money by bank transfer' %}</h1>
 
   <p>
-    {% blocktrans trimmed with amount_to_pay=amount_to_pay|currency_format %}
-      Use your bank’s online or mobile banking to setup a bank transfer for <strong>{{ amount_to_pay }}</strong>.
+    {% blocktrans %}
+    You can send money to a prisoner by making a bank transfer to the prison
+    service account and sort code, using a payment reference to identify the
+    prisoner to whom you wish to send money.
     {% endblocktrans %}
-    {% trans 'Alternatively, you can visit your local branch.' %}
   </p>
+
+  <h3>Payment reference</h3>
+  <p>{% trans 'The payment reference you must use when making the transfer is:' %}</p>
+  <p><code><strong>{{ bank_transfer_reference }}</strong></code></p>
+
+  <h3>Bank details</h3>
   <p>
     {% blocktrans trimmed %}
-      Make the transfer payable to <strong>{{ payable_to }}</strong>,
-      account number <strong>{{ account_number }}</strong>,
-      sort code <strong>{{ sort_code }}</strong>.
-    {% endblocktrans %}
-    {% blocktrans trimmed %}
-      You must include <code><strong>{{ bank_transfer_reference }}</strong></code> as the reference.
+      All public prisons in England and Wales use the same bank account to
+      receive money sent to prisoners. Make a payment using these details:
     {% endblocktrans %}
   </p>
+  <p>{% trans 'The prison service account number' %}</p>
+  <p><code><strong>{{ account_number }}</strong></code></p>
+  <p>{% trans 'The prison service sort code' %}</p>
+  <p><code><strong>{{ sort_code }}</strong></code></p>
+  <p><strong>Remember to enter the payment reference provided above when setting up the transfer.</strong></p>
+  <p>The money should arrive in the prisoner's account in 1 working day<sup>*</sup>.</p>
+  <p>No money is processed at the weekends.</p>
+  <p>If you have any questions about how to make a payment you should contact your bank or building society.</p>
+  <p><sup>*</sup>Your bank may take longer to process payments (up to 3 working days).</p>
+  <p><a href="https://send-money.moneytoprisoners.dsd.io/terms/">Terms and conditions</a></p>
 {% endblock %}

--- a/mtp_send_money/templates/send_money/send-money.html
+++ b/mtp_send_money/templates/send_money/send-money.html
@@ -133,11 +133,7 @@
 
     {% with field=form.payment_method %}
       {# TODO: remove if block once TD allows showing bank transfers #}
-      {% if HIDE_BANK_TRANSFER_OPTION %}
-
-        <input name="{{ field.html_name }}" value="{{ field.value|to_string }}" type="hidden">
-
-      {% else %}
+      {% if SHOW_BANK_TRANSFER_OPTION %}
 
         <div id="{{ field.auto_id }}" class="form-group" style="background: repeating-linear-gradient(-45deg, transparent, transparent 10px, #fee 10px, #fee 20px)">
           <fieldset>
@@ -150,6 +146,10 @@
             {% endfor %}
           </fieldset>
         </div>
+
+      {% else %}
+
+        <input name="{{ field.html_name }}" value="{{ field.value|to_string }}" type="hidden">
 
       {% endif %}
     {% endwith %}

--- a/mtp_send_money/urls.py
+++ b/mtp_send_money/urls.py
@@ -28,7 +28,7 @@ urlpatterns = [
     url(r'^healthcheck.json$', HealthcheckView.as_view(), name='healthcheck_json'),
 ]
 
-if not settings.HIDE_PAYMENT_PAGES:
+if settings.SHOW_DEBIT_CARD_OPTION or settings.SHOW_BANK_TRANSFER_OPTION:
     urlpatterns.append(url(r'^', include('send_money.urls', namespace='send_money',)))
 else:
     urlpatterns.append(url(r'^$', RedirectView.as_view(url=reverse_lazy('submit_ticket'))))


### PR DESCRIPTION
There are now two options, one each for the showing of the debit card flow
and the bank transfer flow. If neither are enabled, only the feedback and
support pages are usable. If only bank transfer is enabled, a simplified
form and instructional page are presented to the user.