### PR TITLE
Send email confirmation on successful debit card payment

### DIFF
--- a/mtp_send_money/apps/send_money/forms.py
+++ b/mtp_send_money/apps/send_money/forms.py
@@ -30,8 +30,12 @@ class PrisonerDetailsForm(GARequestErrorReportingMixin, forms.Form):
         return [field for field in cls.base_fields]
 
     @classmethod
+    def get_required_field_names(cls):
+        return [name for name, field in cls.base_fields.items() if field.required]
+
+    @classmethod
     def session_contains_form_data(cls, session):
-        for required_key in cls.get_field_names():
+        for required_key in cls.get_required_field_names():
             if not session.get(required_key):
                 return False
         return True
@@ -103,6 +107,7 @@ class SendMoneyForm(PrisonerDetailsForm):
     )
     email = forms.EmailField(
         label=_('Your email address'),
+        required=False
     )
 
     def switch_to_hidden(self):
@@ -120,7 +125,7 @@ class SendMoneyForm(PrisonerDetailsForm):
     def form_data_from_session(cls, session):
         try:
             data = {
-                field: session[field]
+                field: session.get(field)
                 for field in cls.get_field_names()
             }
             prisoner_dob = unserialise_date(data['prisoner_dob'])

--- a/mtp_send_money/apps/send_money/forms.py
+++ b/mtp_send_money/apps/send_money/forms.py
@@ -101,6 +101,9 @@ class SendMoneyForm(PrisonerDetailsForm):
         choices=PaymentMethod.django_choices(),
         initial=PaymentMethod.debit_card,
     )
+    email = forms.EmailField(
+        label=_('Your email address'),
+    )
 
     def switch_to_hidden(self):
         for field in self.fields.values():

--- a/mtp_send_money/apps/send_money/tests/test_forms.py
+++ b/mtp_send_money/apps/send_money/tests/test_forms.py
@@ -64,6 +64,18 @@ valid_data_sets = [
         },
     },
     {
+        'name': 'debit_card_no_email',
+        'prisoner_details': {
+            'prisoner_number': 'A1234AB',
+            'prisoner_dob': '1980-10-05',
+        },
+        'data': {
+            'prisoner_name': 'John Smith',
+            'amount': '1000000.00',
+            'payment_method': PaymentMethod.debit_card,
+        },
+    },
+    {
         'name': 'bank_transfer_1',
         'prisoner_details': {
             'prisoner_number': 'A1234AB',

--- a/mtp_send_money/apps/send_money/tests/test_forms.py
+++ b/mtp_send_money/apps/send_money/tests/test_forms.py
@@ -32,6 +32,7 @@ valid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '120.45',
             'payment_method': PaymentMethod.debit_card,
         },
@@ -44,6 +45,7 @@ valid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '12000.00',
             'payment_method': PaymentMethod.debit_card,
         },
@@ -56,6 +58,7 @@ valid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '1000000.00',
             'payment_method': PaymentMethod.debit_card,
         },
@@ -68,6 +71,7 @@ valid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '10',
             'payment_method': PaymentMethod.bank_transfer,
         },
@@ -80,6 +84,7 @@ valid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '100',
             'payment_method': PaymentMethod.bank_transfer,
         },
@@ -136,6 +141,7 @@ invalid_data_sets = [
             'prisoner_dob': '1980-10-05',
         },
         'data': {
+            'email': 'sender@outside.local',
             'amount': '120.45',
             'payment_method': PaymentMethod.debit_card,
         },
@@ -148,6 +154,7 @@ invalid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '120.45',
             'payment_method': PaymentMethod.debit_card,
         },
@@ -160,6 +167,7 @@ invalid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '120.45',
             'payment_method': PaymentMethod.debit_card,
         },
@@ -172,6 +180,7 @@ invalid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '',
             'payment_method': PaymentMethod.debit_card,
         },
@@ -184,6 +193,7 @@ invalid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '120.45',
             'payment_method': '',
         },
@@ -196,6 +206,7 @@ invalid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '120.45',
             'payment_method': PaymentMethod.debit_card,
         },
@@ -208,6 +219,7 @@ invalid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '120.45',
             'payment_method': PaymentMethod.debit_card,
         },
@@ -220,6 +232,7 @@ invalid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '0',
             'payment_method': PaymentMethod.debit_card,
         },
@@ -232,6 +245,7 @@ invalid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '£10',
             'payment_method': PaymentMethod.debit_card,
         },
@@ -244,6 +258,7 @@ invalid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '100.456',
             'payment_method': PaymentMethod.debit_card,
         },
@@ -256,6 +271,7 @@ invalid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '-10',
             'payment_method': PaymentMethod.debit_card,
         },
@@ -268,6 +284,7 @@ invalid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '1000000.01',
             'payment_method': PaymentMethod.debit_card,
         },
@@ -280,6 +297,7 @@ invalid_data_sets = [
         },
         'data': {
             'prisoner_name': 'John Smith',
+            'email': 'sender@outside.local',
             'amount': '100.45',
             'payment_method': 'postal_order',
         },

--- a/mtp_send_money/apps/send_money/tests/test_functional.py
+++ b/mtp_send_money/apps/send_money/tests/test_functional.py
@@ -42,6 +42,7 @@ class SendMoneyFlows(SendMoneyFunctionalTestCase):
                 'prisoner_number': 'A1409AE',
                 'prisoner_dob': '21/01/1989',
                 'amount': '34.50',
+                'email': 'sender@outside.local',
             }), PaymentMethod.bank_transfer)
             self.driver.find_element_by_id('id_next_btn').click()
             self.driver.find_element_by_id('id_next_btn').click()
@@ -56,6 +57,7 @@ class SendMoneyFlows(SendMoneyFunctionalTestCase):
                 'prisoner_number': 'A1409AE',
                 'prisoner_dob': '21/01/1989',
                 'amount': '0.51',
+                'email': 'sender@outside.local',
             }), PaymentMethod.debit_card)
             self.driver.find_element_by_id('id_next_btn').click()
             # TODO: add gov.uk mock and test various responses
@@ -118,6 +120,7 @@ class SendMoneyCheckDetailsPage(SendMoneyFunctionalTestCase):
                 'prisoner_number': 'A1409AE',
                 'prisoner_dob': '21/01/1989',
                 'amount': '34.50',
+                'email': 'sender@outside.local',
             }), PaymentMethod.debit_card)
             self.driver.find_element_by_id('id_next_btn').click()
             self.assertCurrentUrl('/check-details/')

--- a/mtp_send_money/apps/send_money/tests/test_views.py
+++ b/mtp_send_money/apps/send_money/tests/test_views.py
@@ -112,6 +112,18 @@ class SendMoneyViewTestCase(BaseTestCase):
             response = self.submit_send_money_form(mocked_api_client, follow=True)
             self.assertOnPage(response, 'check_details')
 
+    @mock.patch('send_money.utils.api_client')
+    def test_send_money_page_proceeds_without_email(self, mocked_api_client):
+        with reload_payment_urls(self, show_debit_card=True):
+            response = self.submit_send_money_form(mocked_api_client, replace_data={
+                'prisoner_name': SAMPLE_FORM['prisoner_name'],
+                'prisoner_number': SAMPLE_FORM['prisoner_number'],
+                'prisoner_dob': SAMPLE_FORM['prisoner_dob'],
+                'amount': SAMPLE_FORM['amount'],
+                'payment_method': SAMPLE_FORM['payment_method'],
+            }, follow=True)
+            self.assertOnPage(response, 'check_details')
+
     @mock.patch('send_money.forms.PrisonerDetailsForm.check_prisoner_validity')
     def test_send_money_page_displays_errors_for_invalid_prisoner_number(self, mocked_check_prisoner_validity):
         with reload_payment_urls(self, show_debit_card=True):

--- a/mtp_send_money/apps/send_money/views.py
+++ b/mtp_send_money/apps/send_money/views.py
@@ -198,8 +198,9 @@ def debit_card_view(request, context):
         'recipient_name': context['prisoner_name'],
         'prisoner_number': context['prisoner_number'],
         'prisoner_dob': context['prisoner_dob'].isoformat(),
-        'email': context['email']
     }
+    if context.get('email'):
+        new_payment['email'] = context['email']
 
     client = get_api_client()
     try:

--- a/mtp_send_money/assets-src/stylesheets/app.scss
+++ b/mtp_send_money/assets-src/stylesheets/app.scss
@@ -70,6 +70,10 @@ form .form-group .form-hint {
   width: 12em;
 }
 
+.mtp-details {
+  margin-top: 2em;
+}
+
 .mtp-amount {
   margin-top: 2em;
 

--- a/mtp_send_money/settings/base.py
+++ b/mtp_send_money/settings/base.py
@@ -244,6 +244,11 @@ SHOW_DEBIT_CARD_OPTION = os.environ.get('SHOW_DEBIT_CARD_OPTION', 'True') == 'Tr
 GOVUK_PAY_URL = os.environ.get('GOVUK_PAY_URL', '')
 GOVUK_PAY_AUTH_TOKEN = os.environ.get('GOVUK_PAY_AUTH_TOKEN', '')
 
+EMAIL_BACKEND = 'django_mailgun.MailgunBackend'
+MAILGUN_ACCESS_KEY = os.environ.get('MAILGUN_ACCESS_KEY', '')
+MAILGUN_SERVER_NAME = os.environ.get('MAILGUN_SERVER_NAME', '')
+MAILGUN_FROM_ADDRESS = os.environ.get('MAILGUN_FROM_ADDRESS', '')
+
 
 try:
     from .local import *  # noqa

--- a/mtp_send_money/templates/send_money/email/confirmation.txt
+++ b/mtp_send_money/templates/send_money/email/confirmation.txt
@@ -1,0 +1,14 @@
+{% load i18n %}
+{% load send_money %}
+
+{% blocktrans with formatted_ref=payment_ref|upper formatted_amount=amount|currency_format payment_date=payment_created|date:'d/m/Y' %}
+Your payment to a prisoner was successful.
+
+Your reference number is {{ formatted_ref }}.
+
+Payment to: {{ prisoner_name }}
+Payment amount: {{ formatted_amount }}
+Date payment made: {{ payment_date }}
+
+The money will arrive in the prisoner’s account in 3 working days.
+{% endblocktrans %}

--- a/mtp_send_money/templates/send_money/send-money.html
+++ b/mtp_send_money/templates/send_money/send-money.html
@@ -54,6 +54,22 @@
       {% endwith %}
     </fieldset>
 
+    {% with field=form.email %}
+    <div class="mtp-details">
+      <fieldset>
+        <legend class="form-label-bold">{% trans "Your contact details" %}</legend>
+        <div class="form-group {% if field.errors %}error{% endif %}">
+          <label id="{{ field.id_for_label }}-label" class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+          {% for error in field.errors %}
+            <span class="error-message">{{ error }}</span>
+          {% endfor %}
+          <div class="form-hint">{% trans "We will send information about your payment here" %}</div>
+          <input class="form-control" id="{{ field.id_for_label }}" name="{{ field.html_name }}" value="{{ field.value|default:'' }}" type="text"  />
+        </div>
+      </fieldset>
+    </div>
+    {% endwith %}
+
     {% with field=form.amount %}
       <div class="mtp-amount">
         <fieldset>

--- a/mtp_send_money/templates/send_money/send-money.html
+++ b/mtp_send_money/templates/send_money/send-money.html
@@ -14,13 +14,7 @@
     <fieldset>
       <legend class="form-label-bold">{% trans "Prisoner details" %}</legend>
 
-      {% with field=form.prisoner_name %}
-        <div class="form-group {% if field.errors %}error{% endif %}">
-          <label id="{{ field.id_for_label }}-label" class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
-          {% include 'mtp_utils/forms/field-errors.html' with field=field only %}
-          <input class="form-control" id="{{ field.id_for_label }}" name="{{ field.html_name }}" value="{{ field.value|default:'' }}" type="text"  />
-        </div>
-      {% endwith %}
+      {% include 'mtp_utils/forms/field.html' with field=form.prisoner_name only %}
 
       {% with field=form.prisoner_dob %}
         <div class="form-group form-date {% if field.errors %}error{% endif %}">
@@ -54,21 +48,12 @@
       {% endwith %}
     </fieldset>
 
-    {% with field=form.email %}
     <div class="mtp-details">
       <fieldset>
         <legend class="form-label-bold">{% trans "Your contact details" %}</legend>
-        <div class="form-group {% if field.errors %}error{% endif %}">
-          <label id="{{ field.id_for_label }}-label" class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
-          {% for error in field.errors %}
-            <span class="error-message">{{ error }}</span>
-          {% endfor %}
-          <div class="form-hint">{% trans "We will send information about your payment here" %}</div>
-          <input class="form-control" id="{{ field.id_for_label }}" name="{{ field.html_name }}" value="{{ field.value|default:'' }}" type="text"  />
-        </div>
+        {% include 'mtp_utils/forms/field.html' with field=form.email only %}
       </fieldset>
     </div>
-    {% endwith %}
 
     {% with field=form.amount %}
       <div class="mtp-amount">

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,3 +8,4 @@ git+git://github.com/ministryofjustice/django-moj-irat.git
 git+git://github.com/ministryofjustice/django-zendesk-tickets.git
 django-form-error-reporting>=0.2
 pytz>=2015.7
+django-mailgun==0.8.0


### PR DESCRIPTION
Add email field to debit card payment form, and include it in
the creation of the payment record in the API. If the payment is
successful, send a confirmation message to this email address.