### PR TITLE
Show current time for payment date on confirmation page

### DIFF
--- a/mtp_send_money/apps/send_money/views.py
+++ b/mtp_send_money/apps/send_money/views.py
@@ -1,4 +1,3 @@
-import datetime
 from functools import wraps
 import logging
 
@@ -271,8 +270,6 @@ def confirmation_view(request):
             client.payments(payment_ref).patch(payment_update)
             context.update({
                 'success': True,
-                'payment_created': datetime.datetime.strptime(api_response['created'],
-                                                              '%Y-%m-%dT%H:%M:%S.%fZ'),
             })
             if api_response.get('email'):
                 body = loader.get_template(

--- a/mtp_send_money/templates/send_money/confirmation.html
+++ b/mtp_send_money/templates/send_money/confirmation.html
@@ -22,7 +22,7 @@
       <ul>
         <li>{% trans 'Payment to:' %} {{ prisoner_name }}</li>
         <li>{% trans 'Payment amount:' %} {{ amount|currency_format }}</li>
-        <li>{% trans 'Date payment made:' %} {{ payment_created|date:'d/m/Y' }}</li>
+        <li>{% trans 'Date payment made:' %} {% now 'd/m/Y' %}</li>
       </ul>
     </div>
   </div>

--- a/mtp_send_money/templates/send_money/email/confirmation.txt
+++ b/mtp_send_money/templates/send_money/email/confirmation.txt
@@ -1,7 +1,8 @@
 {% load i18n %}
 {% load send_money %}
 
-{% blocktrans with formatted_ref=payment_ref|upper formatted_amount=amount|currency_format payment_date=payment_created|date:'d/m/Y' %}
+{% now 'd/m/Y' as payment_date %}
+{% blocktrans with formatted_ref=payment_ref|upper formatted_amount=amount|currency_format %}
 Dear sender,
 
 Your payment has been successful.


### PR DESCRIPTION
Previously used creation time of payment record, which is not
strictly relevant as it does not reflect the point at which the
payment is taken.