### PR TITLE
Update GOV.UK Pay API integration to match recent changes

### DIFF
--- a/mtp_send_money/apps/send_money/tests/test_views.py
+++ b/mtp_send_money/apps/send_money/tests/test_views.py
@@ -403,7 +403,7 @@ class ConfirmationViewTestCase(BaseTestCase):
                     rsps.GET,
                     govuk_url('/payments/%s/' % processor_id),
                     json={
-                        'status': 'SUCCEEDED'
+                        'state': {'status': 'success'}
                     },
                     status=200
                 )
@@ -445,7 +445,7 @@ class ConfirmationViewTestCase(BaseTestCase):
                     rsps.GET,
                     govuk_url('/payments/%s/' % processor_id),
                     json={
-                        'status': 'SUCCEEDED'
+                        'state': {'status': 'success'}
                     },
                     status=200
                 )

--- a/mtp_send_money/apps/send_money/views.py
+++ b/mtp_send_money/apps/send_money/views.py
@@ -262,7 +262,7 @@ def confirmation_view(request):
         )
 
         if (govuk_response.status_code == 200 and
-                govuk_response.json()['status'] == 'SUCCEEDED'):
+                govuk_response.json()['state']['status'] == 'success'):
             payment_update = {
                 'status': 'taken'
             }


### PR DESCRIPTION
'status' is now a sub-attribute of 'state' and the success
value is now 'success' rather than 'SUCCEEDED'.