### PR TITLE
remove Mojular:

### DIFF
--- a/mtp_send_money/apps/send_money/middleware.py
+++ b/mtp_send_money/apps/send_money/middleware.py
@@ -3,7 +3,6 @@ import logging
 from django.http import Http404
 from django.utils.translation import ugettext as _
 
-from mtp_common.auth import logout
 from mtp_common.auth.exceptions import Unauthorized
 from mtp_common.auth.middleware import AuthenticationMiddleware
 
@@ -16,6 +15,5 @@ class SendMoneyAuthenticationMiddleware(AuthenticationMiddleware):
             logger.error(
                 'Shared send money user was not authorised to access api'
             )
-            logout(request)
             raise Http404(_('Could not connect to service, '
                             'please try again later'))

--- a/mtp_send_money/apps/send_money/tests/test_functional.py
+++ b/mtp_send_money/apps/send_money/tests/test_functional.py
@@ -153,7 +153,7 @@ class SendMoneyFeedbackPages(SendMoneyFunctionalTestCase):
 
     def test_feedback_received_page(self):
         self.driver.get(self.live_server_url + '/feedback/success/')
-        self.assertInSource('<h1>Thank you for your feedback</h1>')
+        self.assertInSource('<h1 class="heading-xlarge">Thank you for your feedback</h1>')
 
 
 @unittest.skipIf('DJANGO_TEST_REMOTE_INTEGRATION_URL' in os.environ, 'test only runs locally')
@@ -176,7 +176,7 @@ class SendMoneyConfirmationPage(SendMoneyFunctionalTestCase):
                 })
 
                 self.driver.get(self.live_server_url + '/confirmation/?payment_ref=REF12345')
-                self.assertInSource('<h1>Send money to a prisoner</h1>')
+                self.assertInSource('<h1 class="heading-xlarge">Send money to a prisoner</h1>')
                 self.assertInSource('Payment was successful')
                 self.assertInSource('Your reference number is <strong>REF12345</strong>')
                 self.assertInSource('What happens next?')

--- a/mtp_send_money/apps/send_money/tests/test_views.py
+++ b/mtp_send_money/apps/send_money/tests/test_views.py
@@ -380,6 +380,7 @@ class ConfirmationViewTestCase(BaseTestCase):
             response = self.client.get(self.url, follow=False)
             self.assertRedirects(response, self.send_money_url)
 
+    @override_settings(ENVIRONMENT='prod')  # because non-prod environments don't send to @outside.local
     def test_confirmation(self):
         with reload_payment_urls(self, show_debit_card=True):
             self.populate_session()

--- a/mtp_send_money/assets-src/javascripts/main.js
+++ b/mtp_send_money/assets-src/javascripts/main.js
@@ -3,22 +3,9 @@
 (function() {
   'use strict';
 
-  var Mojular = require('mojular');
+  require('analytics').Analytics.init();
+  require('element-focus').ElementFocus.init();
 
-  Mojular
-    .use([
-      require('mojular-govuk-elements'),
-      require('mojular-moj-elements'),
-      require('dialog'),
-      require('messages'),
-      require('print'),
-      require('polyfills'),
-      require('unload'),
-      require('help-popup'),
-      require('element-focus'),
+  require('charges').Charges.init();
 
-      require('charges')
-    ])
-    .init();
-
-}());
+})();

--- a/mtp_send_money/assets-src/stylesheets/app-ie6.scss
+++ b/mtp_send_money/assets-src/stylesheets/app-ie6.scss
@@ -1,0 +1,13 @@
+@charset 'UTF-8';
+
+$is-ie: true;
+$ie-version: 6;
+$mobile-ie6: false;
+
+$images-dir: '/static/images/';
+
+@import 'mtp';
+
+form .form-group .form-hint {
+  margin-top: 0;
+}

--- a/mtp_send_money/assets-src/stylesheets/app-ie7.scss
+++ b/mtp_send_money/assets-src/stylesheets/app-ie7.scss
@@ -1,0 +1,12 @@
+@charset 'UTF-8';
+
+$is-ie: true;
+$ie-version: 7;
+
+$images-dir: '/static/images/';
+
+@import 'mtp';
+
+form .form-group .form-hint {
+  margin-top: 0;
+}

--- a/mtp_send_money/assets-src/stylesheets/app-ie8.scss
+++ b/mtp_send_money/assets-src/stylesheets/app-ie8.scss
@@ -1,0 +1,12 @@
+@charset 'UTF-8';
+
+$is-ie: true;
+$ie-version: 8;
+
+$images-dir: '/static/images/';
+
+@import 'mtp';
+
+form .form-group .form-hint {
+  margin-top: 0;
+}

--- a/mtp_send_money/assets-src/stylesheets/app.scss
+++ b/mtp_send_money/assets-src/stylesheets/app.scss
@@ -2,7 +2,7 @@
 
 $images-dir: '/static/images/';
 
-@import 'mtp-public';
+@import 'mtp';
 
 // govuk_elements overrides
 

--- a/mtp_send_money/settings/base.py
+++ b/mtp_send_money/settings/base.py
@@ -94,9 +94,8 @@ TEMPLATES = [
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [
             get_project_dir('templates'),
-            get_project_dir('node_modules'),
-            get_project_dir('../node_modules/mojular-templates'),
-            get_project_dir('../node_modules/money-to-prisoners-common/templates')
+            get_project_dir('assets/templates'),
+            get_project_dir('node_modules')
         ],
         'APP_DIRS': True,
         'OPTIONS': {
@@ -205,10 +204,6 @@ API_URL = os.environ.get('API_URL', find_api_url())
 
 SHARED_API_USERNAME = os.environ.get('SHARED_API_USERNAME', 'send-money')
 SHARED_API_PASSWORD = os.environ.get('SHARED_API_PASSWORD', 'send-money')
-
-LOGIN_URL = 'login'
-LOGIN_REDIRECT_URL = 'send_money:start'
-LOGOUT_URL = 'logout'
 
 OAUTHLIB_INSECURE_TRANSPORT = True
 

--- a/mtp_send_money/settings/docker.py
+++ b/mtp_send_money/settings/docker.py
@@ -2,6 +2,7 @@
 Docker settings
 """
 from .base import *  # noqa
+from .base import ENVIRONMENT, os
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')

--- a/mtp_send_money/settings/jenkins.py
+++ b/mtp_send_money/settings/jenkins.py
@@ -1,4 +1,5 @@
 from .base import *  # noqa
+from .base import INSTALLED_APPS
 
 
 INSTALLED_APPS += (

--- a/mtp_send_money/templates/base.html
+++ b/mtp_send_money/templates/base.html
@@ -1,4 +1,4 @@
-{% extends 'mtp_common/mtp_base_public.html' %}
+{% extends 'mtp_common/mtp_base.html' %}
 {% load i18n %}
 {% load mtp_common %}
 
@@ -8,14 +8,14 @@
   {% sentry_js %}
 {% endblock %}
 
-{% block after_main_js %}
+{% block body_end %}
   {{ block.super }}
   <!-- {{ request.resolver_match.url_name }} -->
 {% endblock %}
 
 {% block page_title %}{% trans 'Send money to a prisoner - GOV.UK' %}{% endblock %}
 
-{% block proposition %}<a href="{% if ENVIRONMENT == 'prod' %}http://sendmoneytoaprisoner.service.justice.gov.uk/{% else %}/{% endif %}" class="proposition-name">{% trans 'Send money to a prisoner' %}</a>{% endblock %}
+{% block proposition %}{% trans 'Send money to a prisoner' %}{% endblock %}
 
 
 {% block phase_banner %}
@@ -29,4 +29,18 @@
       <div class="phase-banner-message"><p>{% blocktrans %}This is a new service. If you need any help please <a href="{{ ticket_url }}">contact us</a>.{% endblocktrans %}</p></div>
     {% endif %}
   </div>
+{% endblock %}
+
+{% block footer_support_links %}
+<ul>
+  <li><a href="/terms/">Terms and conditions</a></li>
+  <li><a href="/cookies/">Cookies</a></li>
+  <li><a href="/feedback/">Feedback</a></li>
+  <li>
+    Built by
+    <a href="https://mojdigital.blog.gov.uk/">
+      <abbr title="Ministry of Justice">MOJ</abbr> Digital
+    </a>
+  </li>
+</ul>
 {% endblock %}

--- a/mtp_send_money/templates/base.html
+++ b/mtp_send_money/templates/base.html
@@ -19,15 +19,25 @@
 
 
 {% block phase_banner %}
-  <div class="subheader-item phase-banner">
-    {% url 'submit_ticket' as ticket_url %}
-    {% if ENVIRONMENT == 'prod' %}
-      <div class="phase-tag phase-tag-alpha">{% trans "Alpha" %}</div>
-      <div class="phase-banner-message"><p>{% blocktrans %}This is a new service. If you need any help please <a href="{{ ticket_url }}">contact us</a>. This is a trial service for family and friends of prisoners at HMP Brixton, HMP Bullingdon, HMP Cardiff and HMP High Down only.{% endblocktrans %}</p></div>
-    {% else %}
-      <div class="phase-tag phase-tag-dev">{{ ENVIRONMENT }}</div>
-      <div class="phase-banner-message"><p>{% blocktrans %}This is a new service. If you need any help please <a href="{{ ticket_url }}">contact us</a>.{% endblocktrans %}</p></div>
-    {% endif %}
+  <div class="phase-banner-alpha">
+    <p>
+      {% url 'submit_ticket' as ticket_url %}
+      {% if ENVIRONMENT == 'prod' %}
+        <strong class="phase-tag">{% trans "Alpha" %}</strong>
+        <span>
+          {% blocktrans trimmed %}
+            This is a new service. If you need any help please <a href="{{ ticket_url }}">contact us</a>. This is a trial service for family and friends of prisoners at HMP Brixton, HMP Bullingdon, HMP Cardiff and HMP High Down only.
+          {% endblocktrans %}
+        </span>
+      {% else %}
+        <strong class="phase-tag phase-tag-dev" title="{{ APP }}-{{ ENVIRONMENT }}:{{ APP_GIT_COMMIT|default:'unknown'|truncatechars:7 }}{% if APP_BUILD_DATE %}, built {{ APP_BUILD_DATE }}{% endif %}">{{ ENVIRONMENT }}</strong>
+        <span>
+          {% blocktrans trimmed %}
+            This is a new service. If you need any help please <a href="{{ ticket_url }}">contact us</a>.
+          {% endblocktrans %}
+        </span>
+      {% endif %}
+    </p>
   </div>
 {% endblock %}
 

--- a/mtp_send_money/templates/base.html
+++ b/mtp_send_money/templates/base.html
@@ -42,15 +42,15 @@
 {% endblock %}
 
 {% block footer_support_links %}
-<ul>
-  <li><a href="/terms/">Terms and conditions</a></li>
-  <li><a href="/cookies/">Cookies</a></li>
-  <li><a href="/feedback/">Feedback</a></li>
-  <li>
-    Built by
-    <a href="https://mojdigital.blog.gov.uk/">
-      <abbr title="Ministry of Justice">MOJ</abbr> Digital
-    </a>
-  </li>
-</ul>
+  <ul>
+    <li><a href="/terms/">{% trans 'Terms and conditions' %}</a></li>
+    <li><a href="/cookies/">{% trans 'Cookies' %}</a></li>
+    <li><a href="/feedback/">{% trans 'Feedback' %}</a></li>
+    <li>
+      {% trans 'Built by' %}
+      <a href="https://mojdigital.blog.gov.uk/">
+        <abbr title="{% trans 'Ministry of Justice' %}">MOJ</abbr> Digital
+      </a>
+    </li>
+  </ul>
 {% endblock %}

--- a/mtp_send_money/templates/cookies.html
+++ b/mtp_send_money/templates/cookies.html
@@ -1,17 +1,17 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block content %}
-  <h1>{% trans 'Cookies' %}</h1>
+{% block inner_content %}
+  <h1 class="heading-xlarge">{% trans 'Cookies' %}</h1>
 
   <p>{% trans 'GOV.UK puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site.' %}</p>
   <p>{% trans 'Cookies are used to:' %}</p>
-  <ul>
+  <ul class="list list-bullet">
     <li>{% trans 'measure how you use the website so it can be updated and improved based on your needs' %}</li>
     <li>{% trans 'remember the notifications you’ve seen so that we don’t show them to you again' %}</li>
   </ul>
 
-  <div class="panel-indent">
+  <div class="panel panel-border-wide">
     <p>{% trans 'GOV.UK cookies aren’t used to identify you personally.' %}</p>
   </div>
 
@@ -20,17 +20,17 @@
     {% trans 'Find out more about <a href="http://www.aboutcookies.org/" rel="external">how to manage cookies</a>.' %}
   </p>
 
-  <h2>{% trans 'How cookies are used on GOV.UK' %}</h2>
-  <h3>{% trans 'Measuring website usage (Google Analytics)' %}</h3>
+  <h2 class="heading-large">{% trans 'How cookies are used on GOV.UK' %}</h2>
+  <h3 class="heading-medium">{% trans 'Measuring website usage (Google Analytics)' %}</h3>
   <p>{% trans 'We use Google Analytics software to collect information about how you use GOV.UK. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.' %}</p>
   <p>{% trans 'Google Analytics stores information about:' %}</p>
-  <ul>
+  <ul class="list list-bullet">
     <li>{% trans 'the pages you visit on GOV.UK - how long you spend on each GOV.UK page' %}</li>
     <li>{% trans 'how you got to the site' %}</li>
     <li>{% trans 'what you click on while you’re visiting the site.' %}</li>
   </ul>
 
-  <div class="panel-indent">
+  <div class="panel panel-border-wide">
     <p>
       {% url 'terms' as terms_url %}
       {% blocktrans trimmed %}
@@ -51,7 +51,7 @@
     </thead>
     <tbody>
       <tr>
-        <td>_ga {% trans 'and' %} _gat</td>
+        <td><code>_ga</code> {% trans 'and' %} <code>_gat</code></td>
         <td>{% trans 'This is a google analytics cookie that helps us understand how the service is being used in detail. Your data is anonymised.' %}</td>
         <td>{% trans '2 years' %}</td>
       </tr>
@@ -62,7 +62,7 @@
     {% trans 'You can <a href="https://tools.google.com/dlpage/gaoptout" rel="external">opt out of Google Analytics cookies</a>.' %}
   </p>
 
-  <h3>{% trans 'Our introductory message' %}</h3>
+  <h3 class="heading-medium">{% trans 'Our introductory message' %}</h3>
   <p>{% trans 'You may see a pop-up welcome message when you first visit GOV.UK. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.' %}</p>
   <table>
     <thead>
@@ -74,14 +74,14 @@
     </thead>
     <tbody>
       <tr>
-        <td>seen_cookie_message</td>
+        <td><code>seen_cookie_message</code></td>
         <td>{% trans 'Saves a message to let us know that you have seen our cookie message' %}</td>
         <td>{% trans '1 month' %}</td>
       </tr>
     </tbody>
   </table>
 
-  <h3>{% trans 'Your progress when using the service' %}</h3>
+  <h3 class="heading-medium">{% trans 'Your progress when using the service' %}</h3>
   <p>{% trans 'When you use the “Send money to a prisoner” service, we’ll set a cookie to remember your progress through the forms. These cookies don’t store your personal data and are deleted once you’ve completed the transaction.' %}</p>
   <table>
     <thead>
@@ -93,7 +93,7 @@
     </thead>
     <tbody>
       <tr>
-        <td>sessionid</td>
+        <td><code>sessionid</code></td>
         <td>{% trans 'An identifier for your session' %}</td>
         <td>{% trans 'At the end of the session' %}</td>
       </tr>

--- a/mtp_send_money/templates/feedback/submit_feedback.html
+++ b/mtp_send_money/templates/feedback/submit_feedback.html
@@ -1,11 +1,11 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block content %}
+{% block inner_content %}
 
 <header class="ContentHeader">
   <a href="{% if ENVIRONMENT == 'prod' %}http://sendmoneytoaprisoner.service.justice.gov.uk/{% else %}{{ return_to|default:'/' }}{% endif %}" class="ContentHeader-back ContentHeader-arrow">{% trans 'Back' %}</a>
-  <h1>{% trans 'Your feedback' %}</h1>
+  <h1 class="heading-xlarge">{% trans 'Your feedback' %}</h1>
 </header>
 
 <form action="." method="post" id="send-feedback">
@@ -18,7 +18,7 @@
   {% with field=form.ticket_content %}
     <div class="form-group {% if field.errors %}error{% endif %}">
       {% include 'mtp_common/forms/field-label.html' with field=field only %}
-      <p><div class="panel-indent panel-border-wide">
+      <p><div class="panel panel-border-wide">
         {% trans 'Please don’t include bank details or any other personal information.' %}
       </div></p>
       {% include 'mtp_common/forms/field-errors.html' with field=field only %}
@@ -26,7 +26,7 @@
     </div>
   {% endwith %}
 
-    <h2>{% trans 'Do you want a reply?' %}</h2>
+    <h2 class="heading-large">{% trans 'Do you want a reply?' %}</h2>
     <p>{% trans 'Enter your email address if you’d like a reply. We won’t use it for anything else.' %}</p>
 
     {% include 'mtp_common/forms/field.html' with field=form.contact_email only %}

--- a/mtp_send_money/templates/feedback/success.html
+++ b/mtp_send_money/templates/feedback/success.html
@@ -1,9 +1,9 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block content %}
+{% block inner_content %}
 <header class="ContentHeader">
   <a href="{% if ENVIRONMENT == 'prod' %}http://sendmoneytoaprisoner.service.justice.gov.uk/{% else %}{{ return_to|default:'/' }}{% endif %}" class="ContentHeader-back ContentHeader-arrow">{% trans 'Back' %}</a>
-  <h1>{% trans 'Thank you for your feedback' %}</h1>
+  <h1 class="heading-xlarge">{% trans 'Thank you for your feedback' %}</h1>
 </header>
-{% endblock content %}
+{% endblock %}

--- a/mtp_send_money/templates/send_money/bank-transfer-form.html
+++ b/mtp_send_money/templates/send_money/bank-transfer-form.html
@@ -3,8 +3,8 @@
 {% load mtp_common %}
 {% load send_money %}
 
-{% block content %}
-  <h1>{% trans 'Who are you sending money to?' %}</h1>
+{% block inner_content %}
+  <h1 class="heading-xlarge">{% trans 'Who are you sending money to?' %}</h1>
 
   <p>
   {% blocktrans %}

--- a/mtp_send_money/templates/send_money/bank-transfer.html
+++ b/mtp_send_money/templates/send_money/bank-transfer.html
@@ -2,17 +2,17 @@
 {% load i18n %}
 {% load send_money %}
 
-{% block content %}
+{% block inner_content %}
 <div class="mtp-bank-transfer">
 
-  <h1>{% trans 'Send the money' %}</h1>
+  <h1 class="heading-xlarge">{% trans 'Send the money' %}</h1>
 
   <section>
-    <h2>{% trans '1. Log in to your online banking or mobile banking app, or telephone your bank' %}</h2>
+    <h2 class="heading-large">{% trans '1. Log in to your online banking or mobile banking app, or telephone your bank' %}</h2>
   </section>
 
   <section>
-    <h2>{% trans '2. Use the following bank details' %}</h2>
+    <h2 class="heading-large">{% trans '2. Use the following bank details' %}</h2>
 
     <dl class="mtp-bank-details">
       <dt>{% trans 'The prison service account number' %}</dt>
@@ -29,9 +29,9 @@
       </dd>
     </dl>
 
-    <div class="panel-indent panel-border-wide">
+    <div class="panel panel-border-wide">
       <p>{% trans 'Please note that:' %}</p>
-      <ul>
+      <ul class="list list-bullet">
         <li>{% trans 'If you’re asked for a ‘payee’, use the prisoner’s name - this is only for your own records and doesn’t affect payment' %}</li>
         <li>{% trans 'If you use the wrong reference, your money will be automatically refunded within 4 working days' %}</li>
         <li>{% trans 'If you try to make a payment in-branch OR make an international payment, the money won’t reach the prisoner and it’s a lengthy process to claim it back' %}</li>
@@ -41,7 +41,7 @@
   </section>
 
   <section>
-    <h2>{% trans '3. The money is paid into the prisoner’s account' %}</h2>
+    <h2 class="heading-large">{% trans '3. The money is paid into the prisoner’s account' %}</h2>
     <p>{% trans 'The money should arrive in the prisoner’s account in 1 working day. However, your bank may take longer to process payment (up to 3 working days).' %}</p>
     <p>{% trans 'No money is processed at weekends.' %}</p>
     <p>{% trans 'If you have any questions about how to make a payment, contact your bank or building society.' %}</p>

--- a/mtp_send_money/templates/send_money/check-details.html
+++ b/mtp_send_money/templates/send_money/check-details.html
@@ -5,8 +5,8 @@
 
 {% block page_title %}{% trans 'Check details - Send money to a prisoner - GOV.UK' %}{% endblock %}
 
-{% block content %}
-  <h1>{% trans 'Check details' %}</h1>
+{% block inner_content %}
+  <h1 class="heading-xlarge">{% trans 'Check details' %}</h1>
 
   <form class="mtp-confirm" method="post" action=".">
     {% csrf_token %}
@@ -14,7 +14,7 @@
 
     <div class="mtp-checkgroup">
       <div class="mtp-confirm-fieldset">
-        <h2>{% trans 'Prisoner details' %}</h2>
+        <h2 class="heading-large">{% trans 'Prisoner details' %}</h2>
 
         {% trans 'Name' %}: {{ form.prisoner_name.value }}<br>
         {% trans 'Date of birth' %}: {{ form.prisoner_dob.value|prepare_prisoner_dob|date:'d/m/Y' }}<br>
@@ -27,7 +27,7 @@
 
     <div class="mtp-checkgroup">
       <div class="mtp-confirm-fieldset">
-        <h2>{% trans 'Money you are sending' %}</h2>
+        <h2 class="heading-large">{% trans 'Money you are sending' %}</h2>
 
         {% if service_charged %}
           {% trans 'Total to prisoner' %}: {{ form.amount.value|currency_format }}<br>

--- a/mtp_send_money/templates/send_money/confirmation.html
+++ b/mtp_send_money/templates/send_money/confirmation.html
@@ -2,8 +2,8 @@
 {% load i18n %}
 {% load send_money %}
 
-{% block content %}
-  <h1>{% trans 'Send money to a prisoner' %}</h1>
+{% block inner_content %}
+  <h1 class="heading-xlarge">{% trans 'Send money to a prisoner' %}</h1>
 
   {% if success %}
   <div class="box-highlight">
@@ -11,15 +11,15 @@
     <p>{% trans 'Your reference number is' %} <strong>{{ payment_ref|upper }}</strong></p>
   </div>
   <div>
-    <h2>{% trans 'What happens next?' %}</h2>
+    <h2 class="heading-large">{% trans 'What happens next?' %}</h2>
 
     <p>{% trans 'The money will arrive in the prisoner’s account in 1 working day.' %} </p>
 
 
     <div>
-      <h3>{% trans 'Payment summary' %}</h3>
+      <h3 class="heading-medium">{% trans 'Payment summary' %}</h3>
 
-      <ul>
+      <ul class="list list-bullet">
         <li>{% trans 'Payment to:' %} {{ prisoner_name }}</li>
         <li>{% trans 'Payment amount:' %} {{ amount|currency_format }}</li>
         <li>{% trans 'Date payment made:' %} {% now 'd/m/Y' %}</li>

--- a/mtp_send_money/templates/send_money/email/confirmation.html
+++ b/mtp_send_money/templates/send_money/email/confirmation.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load send_money %}
 
-{% block content %}
+{% block inner_content %}
   <p>{% trans 'Dear sender,' %}</p>
 
   <p>

--- a/mtp_send_money/templates/send_money/failure.html
+++ b/mtp_send_money/templates/send_money/failure.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block content %}
-  <h1>{% trans 'Send money to a prisoner' %}</h1>
+{% block inner_content %}
+  <h1 class="heading-xlarge">{% trans 'Send money to a prisoner' %}</h1>
 
   <p>{% trans 'We’re sorry, your payment could not be processed on this occasion' %}</p>
   <p>

--- a/mtp_send_money/templates/send_money/send-money.html
+++ b/mtp_send_money/templates/send_money/send-money.html
@@ -3,9 +3,8 @@
 {% load mtp_common %}
 {% load send_money %}
 
-{% block content %}
-  <h1>{% trans 'Generate a prisoner bank transfer reference' %}</h1>
-  <p>You can then use this reference each time you send money to the prisoner.</p>
+{% block inner_content %}
+  <h1 class="heading-xlarge">{% trans 'Who are you sending money to?' %}</h1>
 
   <form method="post" action=".">
     {% csrf_token %}

--- a/mtp_send_money/templates/terms.html
+++ b/mtp_send_money/templates/terms.html
@@ -1,45 +1,45 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block content %}
+{% block inner_content %}
 
   {% blocktrans %}
 
-<h1>Terms and conditions and privacy policy</h1>
+<h1 class="heading-xlarge">Terms and conditions and privacy policy</h1>
 
 <p>By using the send money to a prisoner service using your bank account you agree to our privacy policy and to these terms and conditions. Please read them carefully.</p>
 
-<h2>Terms and conditions</h2>
+<h2 class="heading-large">Terms and conditions</h2>
 
-<h3>General</h3>
+<h3 class="heading-small">General</h3>
 
 <p>These terms and conditions affect your rights and liabilities under the law. They govern your use of, and relationship with, the send money to a prisoner service and information about sending money to prisoners using your bank account. They don’t apply to other services provided by the Ministry of Justice (HM Prison Service), or to any other department or service which is linked to in this service.</p>
 <p>We may occasionally update these terms and conditions. This might happen if there’s a change in the law or to the way this service works. We recommend you check this page regularly for any updates.</p>
 <p>If you don’t agree to the terms and conditions and privacy policy set out in this document, you should not send money to prisoners using your bank account.</p>
 
-<h3>Applicable law</h3>
+<h3 class="heading-small">Applicable law</h3>
 
 <p>Your use of this service and any dispute arising from its use will be governed by and construed in accordance with the laws of England and Wales, including but not limited to the:</p>
-<ul>
+<ul class="list list-bullet">
   <li>Computer Misuse Act 1990</li>
   <li>Data Protection Act 1998</li>
   <li>Mental Capacity Act 2005</li>
 </ul>
 
-<h3>How to use this service responsibly</h3>
+<h3 class="heading-small">How to use this service responsibly</h3>
 
 <p>There are risks in using a shared computer, such as in an internet café, to use this service. It’s your responsibility to be aware of these risks and to avoid using any computer which may leave your personal information accessible to others. You are responsible if you choose to leave a computer unprotected while in the process of sending money to a prisoner.</p>
 <p>We make every effort to check and test this service whenever we amend or update it. However, you must take your own precautions to ensure that the way you access this service does not expose you to the risk of viruses, malicious computer code or other forms of interference which may damage your own computer system.</p>
 <p>You must not misuse our service by knowingly introducing viruses, trojans, worms, logic bombs or other material which is malicious or technologically harmful. You must not attempt to gain unauthorised access to our service, the system on which our service is stored or any server, computer or database connected to our service. You must not attack our site via a denial-of-service attack or a distributed denial-of-service attack.</p>
 
-<h2>Privacy policy</h2>
+<h2 class="heading-large">Privacy policy</h2>
 
-<h3>Information provided by this service</h3>
+<h3 class="heading-small">Information provided by this service</h3>
 
 <p>We work hard to ensure that information about how to send money to a prisoner using your bank account is accurate. However, we can’t guarantee the accuracy and completeness of any information at all times.</p>
 <p>While we make every effort to ensure this service is accessible at all times, we are not liable if it is unavailable for any period of time.</p>
 
-<h3>How we use your information</h3>
+<h3 class="heading-small">How we use your information</h3>
 
 <p>Sending money to a prisoner using your bank account: We use your bank details and the payment reference number you provide to identify the payment sender, as well as the prisoner receiving money. Money coming into the prison is monitored for the purposes of crime detection and prevention.</p>
 <p>You have the right to request details as to the personal information we hold for you; and subsequently request that we correct any personal information if it is found to be inaccurate or out of date. To request your personal data please read the instructions in the <a href="https://www.gov.uk/government/organisations/ministry-of-justice/about/personal-information-charter">Personal Information Charter</a>. You will need a <a href="https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/443730/subject-access-request-form.pdf">Subject Access Request form</a>.</p>
@@ -47,14 +47,14 @@
 <p>Separately from the information entered by those using this service, we also collect site-usage information which allows us to see how the service is being used in order to allow us to improve it. This information does not contain any personal data, unless feedback is submitted with an email address.<p>
 
 <p>It includes:</p>
-<ul>
+<ul class="list list-bullet">
   <li>questions, queries or feedback you leave, including your email address if you send a message via feedback</li>
   <li>your IP address, and details of which version of web browser you used</li>
   <li>information on how you use the site, using cookies and page tagging techniques to help us improve the website</li>
 </ul>
 
 <p>This helps us to:</p>
-<ul>
+<ul class="list list-bullet">
   <li>improve the site by monitoring how you use it</li>
   <li>respond to any feedback you send us, if you’ve asked us to</li>
   <li>provide you with information about local services if you want it</li>
@@ -62,21 +62,21 @@
 
 <p>We can’t personally identify you using your data.</p>
 
-<h3>Using other websites</h3>
+<h3 class="heading-small">Using other websites</h3>
 
 <p>These terms and conditions and privacy policy only cover the send money to a prisoner service and information about it.</p>
 <p>They do not cover links from our website to other third party websites (including bank and building society websites) or any information collected by the parties who own and control those websites or their use of cookies. Individual organisations operate their own policies regarding the use and sale of personal information and the use of cookies.</p>
 <p>When sending money to a prisoner using your bank account, we recommend that you refer to the specific terms and conditions and privacy policy of any banking website or service that you use.</p>
 
-<h3>Where your data is stored</h3>
+<h3 class="heading-small">Where your data is stored</h3>
 
 <p>We store your data on our secure servers in the EEA . However, feedback may be stored outside of the EEA, where it could be viewed by our staff or suppliers. By submitting your personal data, you agree to this.</p>
 <p>We also use other suppliers to provide this service:</p>
-<ul>
+<ul class="list list-bullet">
   <li><a href="https://www.zendesk.com/">Zendesk</a> to handle any feedback that you leave. See the <a href="https://www.zendesk.com/company/terms/">terms &amp; conditions</a> attached to this service.</li>
 </ul>
 
-<h3>Keeping your data secure</h3>
+<h3 class="heading-small">Keeping your data secure</h3>
 
 <p>Transmitting information over the internet is generally not completely secure, and we can’t guarantee the security of your data. We do however use SSL in order to encrypt all data transferred to and received from our server. SSL is an industry standard encryption of the communication between your browser and the server.</p>
 <p>We take data security very seriously and we take every step to ensure that your data remains private and secure.</p>
@@ -86,18 +86,18 @@
 <p>We have procedures and security features in place to try and keep your data secure once we receive it.</p>
 <p>We won’t share your information with any other organisations for marketing, market research or commercial purposes, and we don’t pass on your details to other websites.</p>
 
-<h3>Disclosing your information</h3>
+<h3 class="heading-small">Disclosing your information</h3>
 
 <p>We may pass on your personal information if we have a legal obligation to do so.</p>
 
-<h3>Data Protection Act 1998</h3>
+<h3 class="heading-small">Data Protection Act 1998</h3>
 
 <p>This service complies with all principles of the DPA 1998.</p>
 <p>Ministry of Justice (MoJ) is the ‘data controller’ for the purposes of the Act. However, the information you enter into this service is not automatically transmitted to the Ministry of Justice, but is stored in a secure database. No personal data will be used in testing this service.</p>
 <p>Our hosting provider, and MoJ staff responsible for supporting this service, will have access to the server in which all personal information entered into this service is stored. All staff who have access to the secure data have MoJ security clearance.</p>
 <p>Anyone who believes their personal data is kept within this service has the right to submit a subject access request to the MoJ, who will give details of the information stored on the server.</p>
 
-<h3>Disclaimer</h3>
+<h3 class="heading-small">Disclaimer</h3>
 
 <p>We don’t accept liability for loss or damage incurred by users of this service, whether direct, indirect or consequential, whether caused by tort, breach of contract or otherwise. This includes loss of income or revenue, business, profits or contracts, anticipated savings, data, goodwill, tangible property or wasted time in connection with this service or any websites linked to it and any materials posted on it. This condition shall not prevent claims for loss of or damage to your tangible property or any other claims for direct financial loss that are not excluded by any of the categories set out above.</p>
 <p>This does not affect our liability for death or personal injury arising from our negligence, nor our liability for fraudulent misrepresentation or misrepresentation as to a fundamental matter, nor any other liability which cannot be excluded or limited under applicable law.</p>

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]==3.18.0
+money-to-prisoners-common[testing]==4.1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]==4.1.0
+money-to-prisoners-common[testing]==4.2.0

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]==3.18.0
+money-to-prisoners-common[monitoring]==4.1.0
 
 uWSGI==2.0.12

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]==4.1.0
+money-to-prisoners-common[monitoring]==4.2.0
 
 uWSGI==2.0.12

--- a/run.sh
+++ b/run.sh
@@ -38,10 +38,11 @@ COMMAND=$1
 APP=send_money
 VIRTUAL_ENV_DIR=venv
 NODE_MODULES=node_modules
+GOVUK_TEMPLATE_VERSION=0.17.3
 
 case "$COMMAND" in
     clean)
-        rm -rf $VIRTUAL_ENV_DIR $NODE_MODULES static mtp_$APP/assets
+        rm -rf $VIRTUAL_ENV_DIR $NODE_MODULES static mtp_$APP/assets mtp_$APP/templates/govuk_template
         ;;
     serve | watch | docker | update | build | test | start)
         PORT=8004
@@ -55,6 +56,7 @@ case "$COMMAND" in
             echo "Creating Python virtual environment"
             virtualenv --python=python3 $VIRTUAL_ENV_DIR >/dev/null
           fi
+          echo "Activating Python virtual environment"
           source $VIRTUAL_ENV_DIR/bin/activate >/dev/null
         fi
         PYTHON_BIN=$VIRTUAL_ENV/bin/
@@ -72,7 +74,7 @@ case "$COMMAND" in
         else
             echo "Common resources found at $PYTHON_LIBS"
         fi
-        echo "Installing front-end assets"
+        echo "Installing npm front-end assets"
         npm install >/dev/null
         npm install `cat $PYTHON_LIBS/mtp_common/npm_requirements.txt` >/dev/null
         mkdir -p $MTP_COMMON_NODE_MODULES

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,11 +4,10 @@ var webpack = require('webpack');
 
 module.exports = {
   entry: {
-    app: './mtp_send_money/assets-src/javascripts/main.js',
-    polyfills: ['JSON2', 'html5shiv']
+    app: './mtp_send_money/assets-src/javascripts/main.js'
   },
   output: {
-    path: './mtp_send_money/assets/scripts',
+    path: './mtp_send_money/assets/javascripts',
     filename: '[name].bundle.js'
   },
   module: {
@@ -21,8 +20,7 @@ module.exports = {
   },
   resolve: {
     root: [
-      __dirname + '/node_modules',
-      __dirname + '/node_modules/mojular-moj-elements/node_modules'
+      __dirname + '/node_modules'
     ],
     modulesDirectories: [
       './mtp_send_money/assets-src/javascripts/modules',


### PR DESCRIPTION
* use latest common
* require js scripts the standard way
* add stylesheets for old ie versions
* align to govuk visual styles,
* use govuk classes, markup and template
* find new govuk-templates
* make endblocks consistent
* adapt run script and webpack config
* remove login/logout code
* add public footer links (cookies, terms, etc)
* undo copy changes for generic start page