### PR TITLE
Make prisoner numbers show as uppercase

### DIFF
--- a/mtp_send_money/assets-src/stylesheets/app.scss
+++ b/mtp_send_money/assets-src/stylesheets/app.scss
@@ -64,6 +64,7 @@ form .form-group .form-hint {
 
 .mtp-prisoner-number {
   width: 12em;
+  text-transform: uppercase;
 }
 
 .mtp-details {

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]==4.8.0
+money-to-prisoners-common[testing]==4.9.0

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]==4.8.0
+money-to-prisoners-common[monitoring]==4.9.0
 
 uWSGI==2.0.12


### PR DESCRIPTION
So people won't correct what they type if they see lower-case
(which would work anyway). See https://www.pivotaltracker.com/story/show/121234235