### PR TITLE
Use the GOV.UK Pay captured email rather than capturing ourselves

### DIFF
--- a/mtp_send_money/apps/send_money/forms.py
+++ b/mtp_send_money/apps/send_money/forms.py
@@ -104,11 +104,6 @@ class SendMoneyForm(PrisonerDetailsForm):
             'max_decimal_places': _('Only use 2 decimal places'),
         }
     )
-    email = forms.EmailField(
-        label=_('Your email address'),
-        help_text=_('So we can send you a receipt'),
-        required=False
-    )
 
     def switch_to_hidden(self):
         for field in self.fields.values():

--- a/mtp_send_money/apps/send_money/tests/test_forms.py
+++ b/mtp_send_money/apps/send_money/tests/test_forms.py
@@ -69,7 +69,6 @@ SendMoneyFormTestCase.make_valid_tests([
         },
         'data': {
             'prisoner_name': 'John Smith',
-            'email': 'sender@outside.local',
             'amount': '120.45',
         },
     },
@@ -81,7 +80,6 @@ SendMoneyFormTestCase.make_valid_tests([
         },
         'data': {
             'prisoner_name': 'John Smith',
-            'email': 'sender@outside.local',
             'amount': '12000.00',
         },
     },
@@ -93,7 +91,6 @@ SendMoneyFormTestCase.make_valid_tests([
         },
         'data': {
             'prisoner_name': 'John Smith',
-            'email': 'sender@outside.local',
             'amount': '1000000.00',
         },
     },
@@ -116,7 +113,6 @@ SendMoneyFormTestCase.make_valid_tests([
         },
         'data': {
             'prisoner_name': 'John Smith',
-            'email': 'sender@outside.local',
             'amount': '10',
         },
     },
@@ -128,7 +124,6 @@ SendMoneyFormTestCase.make_valid_tests([
         },
         'data': {
             'prisoner_name': 'John Smith',
-            'email': 'sender@outside.local',
             'amount': '100',
         },
     },
@@ -144,7 +139,6 @@ SendMoneyFormTestCase.make_valid_tests([
             'prisoner_dob_0': '5',
             'prisoner_dob_1': '10',
             'prisoner_dob_2': '80',
-            'email': 'sender@outside.local',
             'amount': '100',
         },
     },
@@ -163,7 +157,6 @@ SendMoneyFormTestCase.make_invalid_tests([
             'prisoner_dob': '1980-10-05',
         },
         'data': {
-            'email': 'sender@outside.local',
             'amount': '120.45',
         },
     },
@@ -175,7 +168,6 @@ SendMoneyFormTestCase.make_invalid_tests([
         },
         'data': {
             'prisoner_name': 'John Smith',
-            'email': 'sender@outside.local',
             'amount': '120.45',
         },
     },
@@ -187,7 +179,6 @@ SendMoneyFormTestCase.make_invalid_tests([
         },
         'data': {
             'prisoner_name': 'John Smith',
-            'email': 'sender@outside.local',
             'amount': '120.45',
         },
     },
@@ -199,7 +190,6 @@ SendMoneyFormTestCase.make_invalid_tests([
         },
         'data': {
             'prisoner_name': 'John Smith',
-            'email': 'sender@outside.local',
             'amount': '',
         },
     },
@@ -211,7 +201,6 @@ SendMoneyFormTestCase.make_invalid_tests([
         },
         'data': {
             'prisoner_name': 'John Smith',
-            'email': 'sender@outside.local',
             'amount': '120.45',
         },
     },
@@ -223,7 +212,6 @@ SendMoneyFormTestCase.make_invalid_tests([
         },
         'data': {
             'prisoner_name': 'John Smith',
-            'email': 'sender@outside.local',
             'amount': '120.45',
         },
     },
@@ -235,7 +223,6 @@ SendMoneyFormTestCase.make_invalid_tests([
         },
         'data': {
             'prisoner_name': 'John Smith',
-            'email': 'sender@outside.local',
             'amount': '0',
         },
     },
@@ -247,7 +234,6 @@ SendMoneyFormTestCase.make_invalid_tests([
         },
         'data': {
             'prisoner_name': 'John Smith',
-            'email': 'sender@outside.local',
             'amount': '£10',
         },
     },
@@ -259,7 +245,6 @@ SendMoneyFormTestCase.make_invalid_tests([
         },
         'data': {
             'prisoner_name': 'John Smith',
-            'email': 'sender@outside.local',
             'amount': '100.456',
         },
     },
@@ -271,7 +256,6 @@ SendMoneyFormTestCase.make_invalid_tests([
         },
         'data': {
             'prisoner_name': 'John Smith',
-            'email': 'sender@outside.local',
             'amount': '-10',
         },
     },
@@ -283,7 +267,6 @@ SendMoneyFormTestCase.make_invalid_tests([
         },
         'data': {
             'prisoner_name': 'John Smith',
-            'email': 'sender@outside.local',
             'amount': '1000000.01',
         },
     },

--- a/mtp_send_money/apps/send_money/tests/test_functional.py
+++ b/mtp_send_money/apps/send_money/tests/test_functional.py
@@ -62,7 +62,6 @@ class SendMoneyFlows(SendMoneyFunctionalTestCase):
                 'prisoner_number': 'A1409AE',
                 'prisoner_dob': '21/01/1989',
                 'amount': '0.51',
-                'email': 'sender@outside.local',
             }), PaymentMethod.debit_card)
             self.driver.find_element_by_id('id_next_btn').click()
             # TODO: add gov.uk mock and test various responses
@@ -75,7 +74,6 @@ class SendMoneyDetailsPage(SendMoneyFunctionalTestCase):
             self.driver.get(self.live_server_url)
             self.assertEqual(self.driver.title, 'Send money to a prisoner - GOV.UK')
             self.assertEqual(self.driver.find_element_by_css_selector('h1').text, 'Who are you sending money to?')
-            self.assertInSource('So we can send you a receipt')
 
     def check_2_digit_entry(self):
         entry_year = random.randrange(0, 99)
@@ -152,7 +150,6 @@ class SendMoneyCheckDetailsPage(SendMoneyFunctionalTestCase):
                 'prisoner_number': 'A1409AE',
                 'prisoner_dob': '21/01/1989',
                 'amount': '34.50',
-                'email': 'sender@outside.local',
             }), PaymentMethod.debit_card)
             self.driver.find_element_by_id('id_next_btn').click()
             self.assertCurrentUrl('/check-details/')
@@ -199,7 +196,7 @@ class SendMoneyConfirmationPage(SendMoneyFunctionalTestCase):
             }
             with responses.RequestsMock() as rsps:
                 rsps.add(rsps.GET, govuk_url('/payments/%s' % processor_id), json={
-                    'state': {'status': 'success'}
+                    'state': {'status': 'success'}, 'email': 'sender@outside.local'
                 })
 
                 self.driver.get(self.live_server_url + '/confirmation/?payment_ref=REF12345')

--- a/mtp_send_money/apps/send_money/tests/test_views.py
+++ b/mtp_send_money/apps/send_money/tests/test_views.py
@@ -24,7 +24,6 @@ SAMPLE_FORM = {
     'prisoner_name': 'John Smith',
     'prisoner_number': 'A1231DE',
     'prisoner_dob': '1980-10-04',
-    'email': 'sender@outside.local',
     'amount': '10.00',
 }
 
@@ -79,7 +78,6 @@ class BaseTestCase(SimpleTestCase):
             data = {
                 'prisoner_name': SAMPLE_FORM['prisoner_name'],
                 'amount': SAMPLE_FORM['amount'],
-                'email': SAMPLE_FORM['email'],
             }
             data.update(prisoner_details)
         else:
@@ -160,17 +158,6 @@ class SendMoneyDebitViewTestCase(BaseTestCase):
             response = self.submit_send_money_form(mocked_api_client, follow=True)
             self.assertOnPage(response, 'check_details')
 
-    @mock.patch('send_money.utils.api_client')
-    def test_send_money_page_proceeds_without_email(self, mocked_api_client):
-        with reload_payment_urls(self, show_debit_card=True):
-            response = self.submit_send_money_form(mocked_api_client, replace_data={
-                'prisoner_name': SAMPLE_FORM['prisoner_name'],
-                'prisoner_number': SAMPLE_FORM['prisoner_number'],
-                'prisoner_dob': SAMPLE_FORM['prisoner_dob'],
-                'amount': SAMPLE_FORM['amount'],
-            }, follow=True)
-            self.assertOnPage(response, 'check_details')
-
     @mock.patch('send_money.forms.PrisonerDetailsForm.check_prisoner_validity')
     def test_send_money_page_displays_errors_for_invalid_prisoner_number(self, mocked_check_prisoner_validity):
         with reload_payment_urls(self, show_debit_card=True):
@@ -178,7 +165,6 @@ class SendMoneyDebitViewTestCase(BaseTestCase):
                 'prisoner_name': 'John Smith',
                 'prisoner_number': 'a1231a1',
                 'prisoner_dob': '1980-10-04',
-                'email': 'sender@outside.local',
                 'amount': '10.00',
             }))
             self.assertContains(response, 'Incorrect prisoner number format')
@@ -192,7 +178,6 @@ class SendMoneyDebitViewTestCase(BaseTestCase):
             response = self.client.post(self.url, data={
                 'prisoner_name': 'John Smith',
                 'prisoner_number': 'A1231DE',
-                'email': 'sender@outside.local',
                 'amount': '10.00',
             })
             self.assertContains(response, 'This field is required')
@@ -208,7 +193,6 @@ class SendMoneyDebitViewTestCase(BaseTestCase):
                 'prisoner_name': 'John Smith',
                 'prisoner_number': 'A1231DE',
                 'prisoner_dob': '1980-10-04',
-                'email': 'sender@outside.local',
                 'amount': '10.00',
             }))
             self.assertContains(response, escape('No prisoner matches the details you’ve supplied'))
@@ -223,7 +207,6 @@ class SendMoneyDebitViewTestCase(BaseTestCase):
                 'prisoner_name': 'John Smith',
                 'prisoner_number': 'A1231DE',
                 'prisoner_dob': '1980-10-04',
-                'email': 'sender@outside.local',
                 'amount': '10.00',
             }))
             self.assertContains(response, 'This service is currently unavailable')
@@ -411,7 +394,6 @@ class ConfirmationViewTestCase(BaseTestCase):
                         'recipient_name': 'John',
                         'amount': 1000,
                         'created': datetime.datetime.now().isoformat() + 'Z',
-                        'email': 'sender@outside.local'
                     },
                     status=200,
                 )
@@ -419,7 +401,7 @@ class ConfirmationViewTestCase(BaseTestCase):
                     rsps.GET,
                     govuk_url('/payments/%s/' % processor_id),
                     json={
-                        'state': {'status': 'success'}
+                        'state': {'status': 'success'}, 'email': 'sender@outside.local'
                     },
                     status=200
                 )
@@ -461,7 +443,7 @@ class ConfirmationViewTestCase(BaseTestCase):
                     rsps.GET,
                     govuk_url('/payments/%s/' % processor_id),
                     json={
-                        'state': {'status': 'success'}
+                        'state': {'status': 'success'}, 'email': 'sender@outside.local'
                     },
                     status=200
                 )

--- a/mtp_send_money/apps/send_money/views.py
+++ b/mtp_send_money/apps/send_money/views.py
@@ -321,14 +321,17 @@ def confirmation_view(request):
             payment_update = {
                 'status': 'taken'
             }
+            email = govuk_response.json().get('email')
+            if email:
+                payment_update['email'] = email
 
             client.payments(payment_ref).patch(payment_update)
             context.update({
                 'success': True,
             })
-            if api_response.get('email'):
+            if email:
                 send_email(
-                    api_response['email'], 'send_money/email/confirmation.txt',
+                    email, 'send_money/email/confirmation.txt',
                     _('Send money to a prisoner: your payment was successful'), context=context,
                     html_template='send_money/email/confirmation.html'
                 )

--- a/mtp_send_money/templates/send_money/send-money.html
+++ b/mtp_send_money/templates/send_money/send-money.html
@@ -48,20 +48,6 @@
       {% endwith %}
     </fieldset>
 
-    <div class="mtp-details">
-      <fieldset>
-        <legend class="form-label-bold">{% trans "Your email address" %}</legend>
-        {% with field=form.email %}
-        <div class="form-group {% if field.errors %}error{% endif %}">
-          <div class="screenreader-only">{% include 'mtp_common/forms/field-label.html' with field=field only %}</div>
-          {% include 'mtp_common/forms/field-help-text.html' with field=field only %}
-          {% include 'mtp_common/forms/field-errors.html' with field=field only %}
-          <input id="{{ field.id_for_label }}" class="form-control" name="{{ field.html_name }}" value="{{ field.value|default:'' }}" type="email" />
-        </div>
-        {% endwith %}
-      </fieldset>
-    </div>
-
     {% with field=form.amount %}
       <div class="mtp-amount">
         <fieldset>


### PR DESCRIPTION
Remove the email field from the prisoner details screen, and store
the email address returned from the GOV.UK Pay API.