### PR TITLE
Improve debit card error flow

### DIFF
--- a/mtp_send_money/templates/send_money/debit-card-confirmation.html
+++ b/mtp_send_money/templates/send_money/debit-card-confirmation.html
@@ -7,7 +7,7 @@
   <div class="govuk-box-highlight">
     <h1 class="heading-large">{% trans 'Payment successful' %}</h1>
     <p>{% trans 'Your payment reference is' %}<p>
-    <strong>{{ short_payment_ref|upper }}</strong>
+    <strong>{{ short_payment_ref }}</strong>
   </div>
 
   <div class="mtp-print print-hidden">
@@ -30,14 +30,16 @@
     </tr>
     <tr>
       <td>{% trans 'Payment reference' %}:</td>
-      <td>{{ short_payment_ref|upper }}</td>
+      <td>{{ short_payment_ref }}</td>
     </tr>
   </table>
 
   <h2 class="heading-medium">{% trans 'What happens next' %}</h2>
 
   <ol class="list list-number">
-    <li>{% trans 'You’ll get email confirmation of payment' %}</li>
+    {% if email_sent %}
+      <li>{% trans 'You’ll get email confirmation of payment' %}</li>
+    {% endif %}
     <li>{% trans 'The money will arrive in the prisoner’s account the next working day.' %}</li>
   </ol>
 

--- a/mtp_send_money/templates/send_money/debit-card-failure.html
+++ b/mtp_send_money/templates/send_money/debit-card-failure.html
@@ -6,8 +6,8 @@
 
   <p>{% trans 'We’re sorry, your payment could not be processed on this occasion' %}</p>
   <p>
-    {% blocktrans trimmed with formatted_ref=short_payment_ref|upper %}
-      Your reference number is <strong>{{ formatted_ref }}</strong>
+    {% blocktrans trimmed %}
+      Your reference number is <strong>{{ short_payment_ref }}</strong>
     {% endblocktrans %}
   </p>
 {% endblock %}

--- a/mtp_send_money/templates/send_money/email/debit-card-confirmation.html
+++ b/mtp_send_money/templates/send_money/email/debit-card-confirmation.html
@@ -6,8 +6,8 @@
   <p>{% trans 'Dear sender,' %}</p>
 
   <p>
-    {% blocktrans trimmed with formatted_ref=short_payment_ref|upper %}
-      Your payment has been successful. Your reference number is <strong>{{ formatted_ref }}</strong>.
+    {% blocktrans trimmed %}
+      Your payment has been successful. Your reference number is <strong>{{ short_payment_ref }}</strong>.
     {% endblocktrans %}
   </p>
 

--- a/mtp_send_money/templates/send_money/email/debit-card-confirmation.txt
+++ b/mtp_send_money/templates/send_money/email/debit-card-confirmation.txt
@@ -2,13 +2,13 @@
 {% load send_money %}
 
 {% now 'd/m/Y' as payment_date %}
-{% blocktrans trimmed with formatted_ref=short_payment_ref|upper formatted_amount=amount|currency_format %}
+{% blocktrans trimmed with formatted_amount=amount|currency_format %}
 GOV.UK - Send money to a prisoner
 
 
 Dear sender,
 
-Your payment has been successful. Your reference number is {{ formatted_ref }}.
+Your payment has been successful. Your reference number is {{ short_payment_ref }}.
 
 The money you sent will reach the prisoner’s account in 1 working day.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 exclude = .git/,node_modules/,venv/
-max-complexity = 12
+max-complexity = 10
 max-line-length = 120


### PR DESCRIPTION
• failed (card rejected or user-cancelled) and cancelled (api-cancelled) gov.uk payments should allow user to retry and aren't actually errors
• if no email address provided or message could not be sent, don't say that one was sent
• more detail in error logs