### PR TITLE
Block access to debit card flow when GOV.UK Pay service has downtime

### DIFF
--- a/mtp_send_money/apps/send_money/forms.py
+++ b/mtp_send_money/apps/send_money/forms.py
@@ -15,7 +15,7 @@ from slumber.exceptions import HttpNotFoundError, SlumberHttpBaseException
 from send_money.models import PaymentMethod
 from send_money.utils import (
     serialise_amount, unserialise_amount, serialise_date, unserialise_date,
-    get_api_client, validate_prisoner_number
+    get_api_client, validate_prisoner_number, check_payment_service_available
 )
 
 logger = logging.getLogger('mtp')
@@ -56,6 +56,9 @@ class PaymentMethodChoiceForm(SendMoneyForm):
         super().__init__(**kwargs)
         if show_bank_transfer_first:
             self['payment_method'].field.choices = reversed(self['payment_method'].field.choices)
+        if not check_payment_service_available():
+            self.fields['payment_method'].initial = PaymentMethod.bank_transfer.name
+            self.fields['payment_method'].disabled = True
 
 
 class PrisonerDetailsForm(SendMoneyForm):

--- a/mtp_send_money/apps/send_money/tests/__init__.py
+++ b/mtp_send_money/apps/send_money/tests/__init__.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.utils.crypto import get_random_string
 from mtp_common.auth.api_client import REQUEST_TOKEN_URL
 
@@ -15,3 +17,8 @@ def mock_auth(rsps):
         },
         status=200,
     )
+
+
+def patch_gov_uk_pay_availability_check():
+    return mock.patch('send_money.forms.check_payment_service_available',
+                      mock.Mock(return_value=True))

--- a/mtp_send_money/apps/send_money/tests/test_forms.py
+++ b/mtp_send_money/apps/send_money/tests/test_forms.py
@@ -10,7 +10,7 @@ from send_money.forms import (
     DebitCardPrisonerDetailsForm, DebitCardAmountForm,
 )
 from send_money.models import PaymentMethod
-from send_money.tests import mock_auth
+from send_money.tests import mock_auth, patch_gov_uk_pay_availability_check
 from send_money.utils import api_url
 
 
@@ -21,8 +21,9 @@ class FormTestCase(unittest.TestCase):
     def make_valid_tests(cls, data_sets):
         def make_method(input_data):
             def test(self):
-                form = self.form_class(data=input_data)
-                self.assertFormValid(form)
+                with patch_gov_uk_pay_availability_check():
+                    form = self.form_class(data=input_data)
+                    self.assertFormValid(form)
 
             return test
 
@@ -33,8 +34,9 @@ class FormTestCase(unittest.TestCase):
     def make_invalid_tests(cls, data_sets):
         def make_method(input_data):
             def test(self):
-                form = self.form_class(data=input_data)
-                self.assertFormInvalid(form)
+                with patch_gov_uk_pay_availability_check():
+                    form = self.form_class(data=input_data)
+                    self.assertFormInvalid(form)
 
             return test
 

--- a/mtp_send_money/assets-src/javascripts/main.js
+++ b/mtp_send_money/assets-src/javascripts/main.js
@@ -3,7 +3,6 @@
 (function() {
   'use strict';
 
-  require('selection-buttons').SelectionButtons.init();
 
   require('analytics').Analytics.init();
   require('element-focus').ElementFocus.init();
@@ -15,4 +14,6 @@
   require('experiments').Experiments.init();
   require('reference').Reference.init();
   require('greyout.js').Greyout.init();
+  require('selection-buttons').SelectionButtons.init();
+  
 })();

--- a/mtp_send_money/assets-src/javascripts/main.js
+++ b/mtp_send_money/assets-src/javascripts/main.js
@@ -14,4 +14,5 @@
   require('charges').Charges.init();
   require('experiments').Experiments.init();
   require('reference').Reference.init();
+  require('greyout.js').Greyout.init();
 })();

--- a/mtp_send_money/assets-src/javascripts/modules/greyout.js
+++ b/mtp_send_money/assets-src/javascripts/modules/greyout.js
@@ -1,0 +1,17 @@
+// Greyout debit card choice when unavailable
+/* globals exports, $ */
+'use strict';
+
+exports.Greyout = {
+
+  init: function () {
+
+    if ($('.error-summary').length) {
+      var $blockLabel = $('.block-label:first');
+      var $debitCardHeader = $('.mtp-debit-header');
+
+      $blockLabel.addClass('mtp-grey-out');
+      $debitCardHeader.addClass('mtp-grey-out');
+    }
+  }
+};

--- a/mtp_send_money/assets-src/javascripts/modules/greyout.js
+++ b/mtp_send_money/assets-src/javascripts/modules/greyout.js
@@ -10,8 +10,8 @@ exports.Greyout = {
       var $blockLabel = $('.block-label:first');
       var $debitCardHeader = $('.mtp-debit-header');
 
-      $blockLabel.addClass('mtp-grey-out');
-      $debitCardHeader.addClass('mtp-grey-out');
+      $blockLabel.addClass('mtp-grey-choice');
+      $debitCardHeader.addClass('mtp-grey-text');
     }
   }
 };

--- a/mtp_send_money/assets-src/stylesheets/app.scss
+++ b/mtp_send_money/assets-src/stylesheets/app.scss
@@ -13,6 +13,7 @@ $images-dir: '/static/images/';
 @import 'elements/typography';
 
 // View-specific styles
+@import 'views/payment-method';
 @import 'views/bank-transfer';
 @import 'views/bank-transfer-form';
 @import 'views/bank-transfer-info';

--- a/mtp_send_money/assets-src/stylesheets/views/_payment-method.scss
+++ b/mtp_send_money/assets-src/stylesheets/views/_payment-method.scss
@@ -1,0 +1,3 @@
+.mtp-error-message {
+  color: #b10e1e;
+}

--- a/mtp_send_money/assets-src/stylesheets/views/_payment-method.scss
+++ b/mtp_send_money/assets-src/stylesheets/views/_payment-method.scss
@@ -1,3 +1,15 @@
-.mtp-error-message {
+// View-specific styles
+
+.mtp-grey-out {
+  opacity: .5;
+
+  &.mtp-debit-header {
+    padding-bottom: 0;
+  }
+}
+
+.mtp-debit-unavailable {
   color: #b10e1e;
+  margin-top: 0;
+  padding-top: 0;
 }

--- a/mtp_send_money/assets-src/stylesheets/views/_payment-method.scss
+++ b/mtp_send_money/assets-src/stylesheets/views/_payment-method.scss
@@ -1,7 +1,18 @@
 // View-specific styles
 
-.mtp-grey-out {
-  opacity: .5;
+.mtp-grey-choice {
+  background: #e8e9eb;
+  border-color: #e8e9eb;
+  color: #696969;
+  cursor: default;
+
+  &:hover {
+    border-color: #e8e9eb;
+  }
+}
+
+.mtp-grey-text {
+  color: #696969;;
 
   &.mtp-debit-header {
     padding-bottom: 0;

--- a/mtp_send_money/templates/send_money/payment-method.html
+++ b/mtp_send_money/templates/send_money/payment-method.html
@@ -15,7 +15,7 @@
 
       {% for payment_method in form.payment_method.field.choices %}
         <label class="block-label" for="id_{{ payment_method.0 }}">
-          <input id="id_{{ payment_method.0 }}" type="radio" name="{{ form.payment_method.html_name }}" value="{{ payment_method.0 }}" {% if form.payment_method.value == payment_method.0 %}checked{% endif %}>
+          <input id="id_{{ payment_method.0 }}" type="radio" name="{{ form.payment_method.html_name }}" value="{{ payment_method.0 }}" {% if form.payment_method.value == payment_method.0 %}checked{% endif %} {%if form.payment_method.field.disabled %}disabled{% endif %}>
           {{ payment_method.1 }}
         </label>
 

--- a/mtp_send_money/templates/send_money/payment-method.html
+++ b/mtp_send_money/templates/send_money/payment-method.html
@@ -13,7 +13,7 @@
     {%if form.payment_method.field.disabled %}
       <div class="error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
 
-        <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+        <h1 class="heading-medium error-summary-heading">
           {% trans 'Due to a technical issue, pay by debit card is temporarily unavailable.' %}
         </h1>
         <p>{% trans 'Please send money using a bank transfer or come back later.' %}</p>
@@ -41,17 +41,18 @@
         <div></div><a href="#">{% trans 'Which is right for me?' %}</a>
       </div>
       <div class="panel panel-border-narrow help-box-contents" id="help-box-contents">
-        <h2 class="heading-small">
+        <h2 class="heading-small mtp-debit-header">
           {% if ENVIRONMENT == 'test' %}
             {% trans 'Pay now by debit card' %}
           {% else %}
             {% trans 'Pay now by debit card (currently HMP Bullingdon and HMP Cardiff only)' %}
           {% endif %}
-          {%if form.payment_method.field.disabled %}
-            <br />
-            <span class="heading-small mtp-error-message">{% trans 'Temporarily unavailable due to a technical issue' %}</span>
-          {% endif %}
         </h2>
+
+        {%if form.payment_method.field.disabled %}
+          <h2 class="heading-small mtp-debit-unavailable">{% trans 'Temporarily unavailable due to a technical issue' %}</h2>
+        {% endif %}
+        
         <ol class="list list-number">
           <li>{% trans 'You can complete your payment here' %}</li>
           <li>{% trans 'Money takes 1 working day to reach the prisoner' %}</li>

--- a/mtp_send_money/templates/send_money/payment-method.html
+++ b/mtp_send_money/templates/send_money/payment-method.html
@@ -10,6 +10,17 @@
     {% csrf_token %}
     {% include 'mtp_common/forms/error-summary.html' with form=form only %}
 
+    {%if form.payment_method.field.disabled %}
+      <div class="error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
+
+        <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+          {% trans 'Due to a technical issue, pay by debit card is temporarily unavailable.' %}
+        </h1>
+        <p>{% trans 'Please send money using a bank transfer or come back later.' %}</p>
+
+      </div>
+    {% endif %}
+
     <fieldset>
       <legend class="visuallyhidden">{% trans 'How do you want to send money?' %}</legend>
 
@@ -35,6 +46,10 @@
             {% trans 'Pay now by debit card' %}
           {% else %}
             {% trans 'Pay now by debit card (currently HMP Bullingdon and HMP Cardiff only)' %}
+          {% endif %}
+          {%if form.payment_method.field.disabled %}
+            <br />
+            <span class="heading-small mtp-error-message">{% trans 'Temporarily unavailable due to a technical issue' %}</span>
           {% endif %}
         </h2>
         <ol class="list list-number">


### PR DESCRIPTION
This is for scheduled or emergency maintenance periods, where one would
add a Downtime record on the API. The payment choice form will be pre-filled
and disabled, and any attempt to access the disabled flow will redirect
the user back to the choice page.