### PR TITLE
Add 'error' to recognised payment states

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 exclude = .git/,node_modules/,venv/
-max-complexity = 10
+max-complexity = 11
 max-line-length = 120


### PR DESCRIPTION
The 'error' state occurs due to technical issues with
GOV.UK or Worldpay, and it should be recognised in order that
the user is redirected to try the payment again (as the copy on
the GOV.UK error page indicates that they will).