### PR TITLE
Remove check for validity of previous forms from debit card success page

### DIFF
--- a/mtp_send_money/apps/send_money/tests/test_views.py
+++ b/mtp_send_money/apps/send_money/tests/test_views.py
@@ -914,6 +914,20 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
             self.assertTrue('WARGLE-B' in mail.outbox[0].body)
             self.assertTrue('£17' in mail.outbox[0].body)
 
+            mock_auth(rsps)
+            rsps.add(
+                rsps.GET,
+                api_url('/payments/%s/' % ref),
+                json={
+                    'processor_id': processor_id,
+                    'recipient_name': 'John',
+                    'amount': 1700,
+                    'status': 'taken',
+                    'created': datetime.datetime.now().isoformat() + 'Z',
+                },
+                status=200,
+            )
+
             with self.patch_prisoner_details_check():
                 response = self.client.get(
                     self.url, {'payment_ref': ref}, follow=True

--- a/mtp_send_money/apps/send_money/views.py
+++ b/mtp_send_money/apps/send_money/views.py
@@ -346,9 +346,8 @@ class DebitCardPaymentView(DebitCardFlow):
         return render(request, 'send_money/debit-card-failure.html', failure_context)
 
 
-class DebitCardConfirmationView(DebitCardFlow, TemplateView):
+class DebitCardConfirmationView(TemplateView):
     url_name = 'confirmation'
-    previous_view = DebitCardPaymentView
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -358,6 +357,11 @@ class DebitCardConfirmationView(DebitCardFlow, TemplateView):
         if self.success:
             return ['send_money/debit-card-confirmation.html']
         return ['send_money/debit-card-failure.html']
+
+    def dispatch(self, request, *args, **kwargs):
+        if not settings.SHOW_DEBIT_CARD_OPTION:
+            raise Http404('Debit cards are not available')
+        return super().dispatch(request, *args, **kwargs)
 
     def get(self, request, *args, **kwargs):
         payment_ref = self.request.GET.get('payment_ref')


### PR DESCRIPTION
This is unnecessary and if the form check fails results in the user
being redirected to the start despite the likely success of their payment.