### PR TITLE
Allow confirmation page to be revisited soon after first viewing

### DIFF
--- a/mtp_send_money/apps/send_money/payments.py
+++ b/mtp_send_money/apps/send_money/payments.py
@@ -18,6 +18,18 @@ from send_money.utils import (
 logger = logging.getLogger('mtp')
 
 
+def is_active_payment(payment):
+    if payment['status'] == 'pending':
+        return True
+
+    received_at = parse_datetime(payment.get('received_at', ''))
+    return (
+        received_at is not None and
+        (timezone.now() - received_at) <
+        timedelta(hours=1)
+    )
+
+
 class PaymentClient:
 
     @cached_property

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 exclude = .git/,node_modules/,venv/
-max-complexity = 11
+max-complexity = 12
 max-line-length = 120


### PR DESCRIPTION
Rather than immediately redirecting a user who returns to the
confirmation page back to the beginning of the process, allow them
to continue to view the confirmation page for up to an hour after
completing the payment.