### PR TITLE
Remove refund link from debit card confirmation page

### DIFF
--- a/mtp_send_money/templates/send_money/debit-card-confirmation.html
+++ b/mtp_send_money/templates/send_money/debit-card-confirmation.html
@@ -44,11 +44,6 @@
   </ol>
 
   <p>
-    {% trans 'To find out more about refunds visit:' %}
-    <a href="{% url 'send_money:help' %}">{% trans 'Help sending money to a prisoner' %}</a>
-  </p>
-
-  <p>
     <a href="https://www.gov.uk/done/send-prisoner-money">{% trans 'Take a moment to rate this service' %}</a>
   </p>
 {% endblock %}


### PR DESCRIPTION
- So that users aren't confused with information that's not relevant to this payment route