### PR TITLE
Handle the case where no gov.uk payment exists for the given reference

### DIFF
--- a/mtp_send_money/apps/send_money/management/commands/update_incomplete_payments.py
+++ b/mtp_send_money/apps/send_money/management/commands/update_incomplete_payments.py
@@ -33,7 +33,9 @@ class Command(BaseCommand):
                     success = payment_client.check_govuk_payment_succeeded(
                         govuk_payment, context
                     )
-                    payment_client.update_completed_payment(govuk_payment, success)
+                    payment_client.update_completed_payment(
+                        payment_ref, govuk_payment, success
+                    )
                 except OAuth2Error:
                     logger.exception(
                         'Scheduled job: Authentication error while processing %s' % payment_ref


### PR DESCRIPTION
This would occur in the case where the creation of a gov.uk payment
fails, leaving an orphaned payment on our side.