### PR TITLE
Avoid sending emails twice for successful payments

### DIFF
--- a/mtp_send_money/apps/send_money/management/commands/update_incomplete_payments.py
+++ b/mtp_send_money/apps/send_money/management/commands/update_incomplete_payments.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
                 try:
                     govuk_payment = payment_client.get_govuk_payment(govuk_id)
                     success = payment_client.check_govuk_payment_succeeded(
-                        govuk_payment, context
+                        payment, govuk_payment, context
                     )
                     payment_client.update_completed_payment(
                         payment_ref, govuk_payment, success

--- a/mtp_send_money/apps/send_money/tests/test_commands.py
+++ b/mtp_send_money/apps/send_money/tests/test_commands.py
@@ -86,6 +86,11 @@ class UpdateIncompletePaymentsTestCase(SimpleTestCase):
                 status=200,
             )
             rsps.add(
+                rsps.PATCH,
+                api_url('/payments/%s/' % 'wargle-1111'),
+                status=200,
+            )
+            rsps.add(
                 rsps.GET,
                 govuk_url('/payments/%s/' % 2),
                 json={

--- a/mtp_send_money/apps/send_money/tests/test_functional.py
+++ b/mtp_send_money/apps/send_money/tests/test_functional.py
@@ -214,6 +214,7 @@ class SendMoneyConfirmationPage(SendMoneyFunctionalTestCase):
     def test_success_page(self, mocked_client):
         processor_id = '3'
         mocked_client().payments().get.return_value = {
+            'uuid': 'wargle-blargle',
             'processor_id': processor_id,
             'recipient_name': 'James Bond',
             'amount': 2000,
@@ -244,7 +245,7 @@ class SendMoneyConfirmationPage(SendMoneyFunctionalTestCase):
     def test_failure_page(self, mocked_client):
         processor_id = '3'
         mocked_client().payments().get.return_value = {
-            'reference': 'wargle-blargle',
+            'uuid': 'wargle-blargle',
             'processor_id': processor_id,
             'recipient_name': 'James Bond',
             'amount': 2000,

--- a/mtp_send_money/apps/send_money/tests/test_views.py
+++ b/mtp_send_money/apps/send_money/tests/test_views.py
@@ -859,6 +859,7 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
                 rsps.GET,
                 api_url('/payments/%s/' % ref),
                 json={
+                    'uuid': ref,
                     'processor_id': processor_id,
                     'recipient_name': 'John',
                     'amount': 1700,
@@ -882,6 +883,11 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
                     }
                 },
                 status=200
+            )
+            rsps.add(
+                rsps.PATCH,
+                api_url('/payments/%s/' % 'wargle-blargle'),
+                status=200,
             )
             with self.patch_prisoner_details_check():
                 response = self.client.get(
@@ -934,6 +940,7 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
                 rsps.GET,
                 api_url('/payments/%s/' % ref),
                 json={
+                    'uuid': ref,
                     'processor_id': processor_id,
                     'recipient_name': 'John',
                     'amount': 1700,
@@ -972,6 +979,7 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
                 rsps.GET,
                 api_url('/payments/%s/' % ref),
                 json={
+                    'uuid': ref,
                     'processor_id': processor_id,
                     'recipient_name': 'John',
                     'amount': 1700,
@@ -1015,6 +1023,7 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
                 rsps.GET,
                 api_url('/payments/%s/' % ref),
                 json={
+                    'uuid': ref,
                     'processor_id': processor_id,
                     'recipient_name': 'John',
                     'amount': 1700,
@@ -1049,6 +1058,7 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
                 rsps.GET,
                 api_url('/payments/%s/' % ref),
                 json={
+                    'uuid': ref,
                     'processor_id': processor_id,
                     'recipient_name': 'John',
                     'amount': 1700,
@@ -1081,6 +1091,7 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
                 rsps.GET,
                 api_url('/payments/%s/' % ref),
                 json={
+                    'uuid': ref,
                     'processor_id': processor_id,
                     'recipient_name': 'John',
                     'amount': 1700,

--- a/mtp_send_money/apps/send_money/views.py
+++ b/mtp_send_money/apps/send_money/views.py
@@ -388,7 +388,7 @@ class DebitCardConfirmationView(TemplateView):
                 govuk_id = payment['processor_id']
                 govuk_payment = payment_client.get_govuk_payment(govuk_id)
                 self.success = payment_client.check_govuk_payment_succeeded(
-                    govuk_payment, kwargs
+                    payment, govuk_payment, kwargs
                 )
             if not self.success:
                 return redirect(build_view_url(self.request, DebitCardCheckView.url_name))


### PR DESCRIPTION
As we update the payments asynchronously, every payment will typically
be processed twice, once synchronously (with no update) and once
asynchronously (with an update). As in order to ensure that an email
confirmation is received (and promptly) both of these cases result in
an email being sent, it is necessary to add a way to check if it has
been sent already. This is done buy updating that email field on the
payment when the email is sent, and checking it before sending it again.