### PR TITLE
Get capture time from new settlement_summary field

### DIFF
--- a/mtp_send_money/apps/send_money/tests/test_views.py
+++ b/mtp_send_money/apps/send_money/tests/test_views.py
@@ -875,12 +875,10 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
                     'reference': 'wargle-blargle',
                     'state': {'status': 'success'},
                     'email': 'sender@outside.local',
-                    '_links': {
-                        'events': {
-                            'method': 'GET',
-                            'href': govuk_url('/payments/%s/events' % 1),
-                        }
-                    }
+                    'settlement_summary': {
+                        'capture_submit_time': None,
+                        'captured_date': None
+                    },
                 },
                 status=200
             )


### PR DESCRIPTION
This is a new JSON block added to the payment response containing
accurate capture information. It includes the time the capture was
submitted, and the date that it was actually captured. If the
captured_date is later than the submit time, the received_at
attribute of the payment is set to match the captured_date
in order to match the settlement batches we receive from worldpay.