### PR TITLE
Remove time limit on API payments to check status of on GOV.UK pay

### DIFF
--- a/mtp_send_money/apps/send_money/payments.py
+++ b/mtp_send_money/apps/send_money/payments.py
@@ -45,10 +45,7 @@ class PaymentClient:
         return api_response['uuid']
 
     def get_incomplete_payments(self):
-        an_hour_ago = timezone.now() - timedelta(hours=1)
-        return retrieve_all_pages(
-            self.client.payments.get, modified__lt=an_hour_ago.isoformat()
-        )
+        return retrieve_all_pages(self.client.payments.get)
 
     def get_payment(self, payment_ref):
         from slumber.exceptions import HttpNotFoundError


### PR DESCRIPTION
All payments should eventually have a resolution, but there is no
hard limit on when that resolution may be. The time limit was leading
to some payments being "forgotten".