### PR TITLE
Use the current time for received_at if the capture submit time is absent

### DIFF
--- a/mtp_send_money/apps/send_money/payments.py
+++ b/mtp_send_money/apps/send_money/payments.py
@@ -139,8 +139,10 @@ class PaymentClient:
             captured_date = parse_date(
                 govuk_payment['settlement_summary'].get('captured_date', '')
             )
-            if capture_submit_time is not None and captured_date is not None:
-                capture_submit_time = capture_submit_time.astimezone(timezone.utc)
+            if captured_date is not None:
+                capture_submit_time = (
+                    capture_submit_time or timezone.now()
+                ).astimezone(timezone.utc)
                 if capture_submit_time.date() < captured_date:
                     return datetime.combine(
                         captured_date, time.min

--- a/mtp_send_money/apps/send_money/tests/test_commands.py
+++ b/mtp_send_money/apps/send_money/tests/test_commands.py
@@ -1,10 +1,12 @@
 from datetime import datetime
 import json
+from unittest import mock
 
 from django.core import mail
 from django.core.management import call_command
 from django.test import override_settings
 from django.test.testcases import SimpleTestCase
+from django.utils.timezone import utc
 import responses
 
 from send_money.tests import mock_auth
@@ -309,6 +311,13 @@ class UpdateIncompletePaymentsTestCase(SimpleTestCase):
                 received_at
             )
 
+    def test_submit_time_used_when_date_the_same(self):
+        self._test_received_at_date_matches_captured_date(
+            '2016-10-28T14:57:05Z',
+            '2016-10-28',
+            '2016-10-28T14:57:05+00:00'
+        )
+
     def test_received_at_date_is_put_forward(self):
         self._test_received_at_date_matches_captured_date(
             '2016-10-27T23:57:05Z',
@@ -323,4 +332,13 @@ class UpdateIncompletePaymentsTestCase(SimpleTestCase):
             '2016-10-28T00:57:05+01:00',
             '2016-10-28',
             '2016-10-28T00:00:00+00:00'
+        )
+
+    @mock.patch('mtp_send_money.apps.send_money.payments.timezone.now')
+    def test_received_at_date_is_set_to_now_when_submit_time_absent(self, mock_now):
+        mock_now.return_value = datetime(2016, 10, 28, 12, 45, 22, tzinfo=utc)
+        self._test_received_at_date_matches_captured_date(
+            '',
+            '2016-10-28',
+            '2016-10-28T12:45:22+00:00'
         )


### PR DESCRIPTION
If Worldpay does not respond to the capture submission, gov.uk pay do
not record the capture submit time. However, the payment may still end
up being captured, in which case we should fall back to the current time
to inform the received_at timestamp.