### PR TITLE
Use "first instance" check when updating incomplete payments

### DIFF
--- a/mtp_send_money/apps/send_money/management/commands/update_incomplete_payments.py
+++ b/mtp_send_money/apps/send_money/management/commands/update_incomplete_payments.py
@@ -1,8 +1,8 @@
 from decimal import Decimal
 import logging
 
-from django.conf import settings
 from django.core.management import BaseCommand
+from mtp_common.stack import StackException, InstanceNotInAsgException, is_first_instance
 from oauthlib.oauth2 import OAuth2Error
 from requests.exceptions import RequestException
 
@@ -13,37 +13,54 @@ logger = logging.getLogger('mtp')
 
 
 class Command(BaseCommand):
+    def handle(self, **options):
+        verbosity = options['verbosity']
+        if self.should_perform_update():
+            if verbosity:
+                self.stdout.write('Updating incomplete payments')
+            self.perform_update()
+        elif verbosity:
+            self.stdout.write('Not updating incomplete payments because running on secondary instance')
 
-    def handle(self, *args, **options):
-        if settings.RUN_CLEANUP_TASKS:
-            payment_client = PaymentClient()
-            payments = payment_client.get_incomplete_payments()
-            for payment in payments:
-                payment_ref = payment['uuid']
-                govuk_id = payment['processor_id']
-                context = {
-                    'short_payment_ref': payment_ref[:8].upper(),
-                    'prisoner_name': payment['recipient_name'],
-                    'amount': Decimal(payment['amount']) / 100,
-                }
+    def should_perform_update(self):
+        try:
+            return is_first_instance()
+        except InstanceNotInAsgException:
+            self.stderr.write('EC2 instance not in an ASG')
+            return True
+        except StackException:
+            self.stderr.write('Not running on EC2 instance')
+            return True
 
-                try:
-                    govuk_payment = payment_client.get_govuk_payment(govuk_id)
-                    success = payment_client.check_govuk_payment_succeeded(
-                        payment, govuk_payment, context
-                    )
-                    payment_client.update_completed_payment(
-                        payment_ref, govuk_payment, success
-                    )
-                except OAuth2Error:
-                    logger.exception(
-                        'Scheduled job: Authentication error while processing %s' % payment_ref
-                    )
-                except RequestException as error:
-                    error_message = 'Scheduled job: Payment check failed for ref %s' % payment_ref
-                    if hasattr(error, 'response') and hasattr(error.response, 'content'):
-                        error_message += '\nReceived: %s' % error.response.content
-                    logger.exception(error_message)
-                except GovUkPaymentStatusException:
-                    # expected much of the time
-                    pass
+    def perform_update(self):
+        payment_client = PaymentClient()
+        payments = payment_client.get_incomplete_payments()
+        for payment in payments:
+            payment_ref = payment['uuid']
+            govuk_id = payment['processor_id']
+            context = {
+                'short_payment_ref': payment_ref[:8].upper(),
+                'prisoner_name': payment['recipient_name'],
+                'amount': Decimal(payment['amount']) / 100,
+            }
+
+            try:
+                govuk_payment = payment_client.get_govuk_payment(govuk_id)
+                success = payment_client.check_govuk_payment_succeeded(
+                    payment, govuk_payment, context
+                )
+                payment_client.update_completed_payment(
+                    payment_ref, govuk_payment, success
+                )
+            except OAuth2Error:
+                logger.exception(
+                    'Scheduled job: Authentication error while processing %s' % payment_ref
+                )
+            except RequestException as error:
+                error_message = 'Scheduled job: Payment check failed for ref %s' % payment_ref
+                if hasattr(error, 'response') and hasattr(error.response, 'content'):
+                    error_message += '\nReceived: %s' % error.response.content
+                logger.exception(error_message)
+            except GovUkPaymentStatusException:
+                # expected much of the time
+                pass

--- a/mtp_send_money/apps/send_money/tests/test_commands.py
+++ b/mtp_send_money/apps/send_money/tests/test_commands.py
@@ -14,8 +14,18 @@ from send_money.utils import api_url, govuk_url
 
 
 @override_settings(GOVUK_PAY_URL='https://pay.gov.local/v1')
-@override_settings(RUN_CLEANUP_TASKS=True)
 class UpdateIncompletePaymentsTestCase(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.mocked_is_first_instance = mock.patch(
+            'send_money.management.commands.update_incomplete_payments.is_first_instance',
+            return_value=True
+        )
+        self.mocked_is_first_instance.start()
+
+    def tearDown(self):
+        self.mocked_is_first_instance.stop()
+        super().tearDown()
 
     @override_settings(ENVIRONMENT='prod')  # because non-prod environments don't send to @outside.local
     def test_update_incomplete_payments(self):
@@ -119,7 +129,7 @@ class UpdateIncompletePaymentsTestCase(SimpleTestCase):
                 status=200,
             )
 
-            call_command('update_incomplete_payments')
+            call_command('update_incomplete_payments', verbosity=0)
 
             self.assertEqual(
                 json.loads(rsps.calls[-5].request.body.decode())['email'],
@@ -174,7 +184,7 @@ class UpdateIncompletePaymentsTestCase(SimpleTestCase):
                 status=200,
             )
 
-            call_command('update_incomplete_payments')
+            call_command('update_incomplete_payments', verbosity=0)
 
             self.assertEqual(rsps.calls[3].request.body.decode(), '{"status": "failed"}')
 
@@ -208,7 +218,7 @@ class UpdateIncompletePaymentsTestCase(SimpleTestCase):
                 status=200,
             )
 
-            call_command('update_incomplete_payments')
+            call_command('update_incomplete_payments', verbosity=0)
 
             self.assertEqual(len(mail.outbox), 0)
 
@@ -234,7 +244,7 @@ class UpdateIncompletePaymentsTestCase(SimpleTestCase):
                 status=200
             )
 
-            call_command('update_incomplete_payments')
+            call_command('update_incomplete_payments', verbosity=0)
 
             self.assertEqual(len(mail.outbox), 0)
 
@@ -291,7 +301,7 @@ class UpdateIncompletePaymentsTestCase(SimpleTestCase):
                 status=200,
             )
 
-            call_command('update_incomplete_payments')
+            call_command('update_incomplete_payments', verbosity=0)
 
             self.assertEqual(
                 json.loads(rsps.calls[-1].request.body.decode())['received_at'],

--- a/mtp_send_money/settings/base.py
+++ b/mtp_send_money/settings/base.py
@@ -276,8 +276,6 @@ MAILGUN_FROM_ADDRESS = os.environ.get('MAILGUN_FROM_ADDRESS', '')
 if MAILGUN_FROM_ADDRESS:
     DEFAULT_FROM_EMAIL = MAILGUN_FROM_ADDRESS
 
-RUN_CLEANUP_TASKS = os.environ.get('RUN_CLEANUP_TASKS', 'False') == 'True'
-
 try:
     from .local import *  # noqa
 except ImportError:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=6.7,<6.8
+money-to-prisoners-common[testing]>=6.8,<6.9

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=6.7,<6.8
+money-to-prisoners-common[monitoring]>=6.8,<6.9
 
 uWSGI==2.0.15


### PR DESCRIPTION
because using the template-deploy-managed environment variable is unreliable
the default action is to update if status cannot be determined