### PR TITLE
Bank transfer refunds have MTP NOMS as the sender

### DIFF
--- a/mtp_send_money/templates/send_money/help/bank-transfer-issues.html
+++ b/mtp_send_money/templates/send_money/help/bank-transfer-issues.html
@@ -25,7 +25,7 @@
       </p>
       <p>
         {% trans 'If so, you’ll get a refund within 4 working days of making the bank transfer.' %}
-        {% trans 'Your bank statement will show ‘GBS RE NOMS AGENCY’ and the reference will be ‘REFUND’.' %}
+        {% trans 'Your bank statement will show ‘MTP NOMS’.' %}
       </p>
       <p>
         {% trans 'No money will reach the prisoner.' %}


### PR DESCRIPTION
rather than GBS RE NOMS AGENCY