### PR TITLE
Add honeypot field to contact form to try and lessen bot spam

### DIFF
--- a/mtp_send_money/apps/feedback/forms.py
+++ b/mtp_send_money/apps/feedback/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 from zendesk_tickets.forms import EmailTicketForm
 
@@ -30,3 +31,13 @@ class ContactForm(EmailTicketForm):
         help_text=_('We won’t use it for anything else'),
         required=False
     )
+    # `subject` is a hidden honeypot field to try and lessen bot spam
+    subject = forms.CharField(
+        label='What is the subject of your enquiry?',
+        required=False,
+    )
+
+    def clean(self):
+        if self.cleaned_data['subject']:
+            raise ValidationError(_('The service is currently unavailable'))
+        return self.cleaned_data

--- a/mtp_send_money/templates/send_money/contact-form.html
+++ b/mtp_send_money/templates/send_money/contact-form.html
@@ -25,6 +25,10 @@
         <fieldset>
           <legend class="visually-hidden">{% trans 'Your message' %}</legend>
 
+          <div class="hidden">
+            {% include 'mtp_common/forms/field.html' with field=form.subject only %}
+          </div>
+
           {% with field=form.ticket_content value=request.GET.message|default:'' %}
             <div class="form-group {% if field.errors %}form-group-error{% endif %}">
               {% include 'mtp_common/forms/field-label.html' with field=field only %}


### PR DESCRIPTION
We've started getting bots submittign spam tickets via the contact us
form. Before going so far as to consider adding a captcha, trying the
addition of a honeypot field to the form to see if that helps.