### PR TITLE
Allow ongoing payments to complete when card payment option is turned off

### DIFF
--- a/mtp_send_money/apps/send_money/forms.py
+++ b/mtp_send_money/apps/send_money/forms.py
@@ -63,16 +63,18 @@ class PaymentMethodChoiceForm(SendMoneyForm):
         'required': _('Please choose how you want to send money')
     }, choices=PaymentMethod.django_choices())
 
-    def __init__(self, show_bank_transfer_first=False, **kwargs):
+    def __init__(self, show_bank_transfer_first=False, check_debit_card_payment_availability=False, **kwargs):
         super().__init__(**kwargs)
         payment_method_field = self.fields['payment_method']
         if show_bank_transfer_first:
             payment_method_field.choices = reversed(payment_method_field.choices)
-        payment_service_available, message_to_users = check_payment_service_available()
-        if not payment_service_available:
-            payment_method_field.message_to_users = message_to_users
-            payment_method_field.initial = PaymentMethod.bank_transfer.name
-            payment_method_field.disabled = True
+
+        if check_debit_card_payment_availability:
+            payment_service_available, message_to_users = check_payment_service_available()
+            if not payment_service_available:
+                payment_method_field.message_to_users = message_to_users
+                payment_method_field.initial = PaymentMethod.bank_transfer.name
+                payment_method_field.disabled = True
 
 
 class PrisonerDetailsForm(SendMoneyForm):

--- a/mtp_send_money/apps/send_money/views.py
+++ b/mtp_send_money/apps/send_money/views.py
@@ -123,6 +123,10 @@ class PaymentMethodChoiceView(SendMoneyFormView):
         self.set_experiment_cookie = None
 
     def dispatch(self, request, *args, **kwargs):
+        # reset the session so that we can start fresh
+        if not request.session.is_empty():
+            request.session.flush()
+
         if settings.SHOW_BANK_TRANSFER_OPTION and settings.SHOW_DEBIT_CARD_OPTION:
             response = super().dispatch(request, *args, **kwargs)
             if self.set_experiment_cookie is not None:
@@ -171,8 +175,12 @@ class PaymentMethodChoiceView(SendMoneyFormView):
         return context_data
 
     def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs['show_bank_transfer_first'] = self.show_bank_transfer_first
+        kwargs = {
+            **super().get_form_kwargs(),
+
+            'show_bank_transfer_first': self.show_bank_transfer_first,
+            'check_debit_card_payment_availability': True,
+        }
         return kwargs
 
     def form_valid(self, form):


### PR DESCRIPTION
This allows payments that started before the card payment option was turned off to complete whilst stopping new payments from starting.