### PR TITLE
Add support for curated notifications

### DIFF
--- a/mtp_send_money/assets-src/javascripts/main.js
+++ b/mtp_send_money/assets-src/javascripts/main.js
@@ -8,6 +8,7 @@
   require('element-focus').ElementFocus.init();
   require('year-field-completion').YearFieldCompletion.init();
   require('disclosure').Disclosure.init();
+  require('notifications').Notifications.init();
 
   require('charges').Charges.init();
   require('govuk-pay-connection-check').GOVUKPayConnectionCheck.init();

--- a/mtp_send_money/assets-src/stylesheets/app.scss
+++ b/mtp_send_money/assets-src/stylesheets/app.scss
@@ -3,7 +3,7 @@
 // Application elements
 @import 'elements/banners';
 @import 'elements/typography';
-@import 'internal/notifications';
+@import 'elements/notifications';
 
 // View-specific styles
 @import 'views/payment-method';

--- a/mtp_send_money/assets-src/stylesheets/app.scss
+++ b/mtp_send_money/assets-src/stylesheets/app.scss
@@ -3,6 +3,7 @@
 // Application elements
 @import 'elements/banners';
 @import 'elements/typography';
+@import 'internal/notifications';
 
 // View-specific styles
 @import 'views/payment-method';

--- a/mtp_send_money/templates/send_money/payment-method.html
+++ b/mtp_send_money/templates/send_money/payment-method.html
@@ -5,6 +5,8 @@
 {% block page_title %}{% trans 'How do you want to send money?' %} – {{ block.super }}{% endblock %}
 
 {% block inner_content %}
+  {% notifications_box request 'send_money_landing' %}
+
   <header>
     <h1 class="heading-xlarge">{% trans 'How do you want to send money?' %}</h1>
   </header>

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=9.11.1,<9.12
+money-to-prisoners-common[testing]>=9.11.3,<9.12

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=9.11.1,<9.12
+money-to-prisoners-common[monitoring]>=9.11.3,<9.12
 
 uWSGI==2.0.17


### PR DESCRIPTION
It is now possible to display a message on the landing page with content set via the django admin. 
The logic is the same used in the internal services.

~@ushkarev the css imports notifications from `internal/notifications` which is a bit dirty, I would have preferred to move `_notifications.scss` out of the `internal` folder but I would have to update and deploy all the other services.
Do you think it's okay to leave it as it is instead?~

Update: I moved `_notifications.scss` out of the internal folder.