### PR TITLE
Change DebitCardConfirmationView to check govuk status

### DIFF
--- a/mtp_send_money/apps/send_money/payments.py
+++ b/mtp_send_money/apps/send_money/payments.py
@@ -35,6 +35,12 @@ class PaymentStatus(enum.Enum):
     def finished(self):
         return self in [self.success, self.failed, self.cancelled, self.error]
 
+    def finished_and_failed(self):
+        return self.finished() and self != self.success
+
+    def is_awaiting_user_input(self):
+        return self in [self.created, self.started, self.submitted]
+
 
 def is_active_payment(payment):
     if payment['status'] == 'pending':


### PR DESCRIPTION
This refactors the `DebitCardConfirmationView` to use the new `PaymentClient.check_govuk_payment_status` method so that it can be extended to do different things in case of capturable payments.

It also tweaks and adds some tests to make sure we are covering all cases.

This doesn't actually change the current logic but it's already big so it's better if it goes in before other changes.