### PR TITLE
Automatically capture payments

### DIFF
--- a/mtp_send_money/apps/send_money/payments.py
+++ b/mtp_send_money/apps/send_money/payments.py
@@ -151,7 +151,7 @@ class PaymentClient:
         elif govuk_status == PaymentStatus.capturable:
             if self.should_be_automatically_captured(payment):
                 # capture payment and send successful email
-                govuk_status = self.capture_payment(govuk_payment, context)
+                govuk_status = self.capture_govuk_payment(govuk_payment, context)
 
         # update email if necessary
         if should_update_email:
@@ -160,7 +160,7 @@ class PaymentClient:
 
         return govuk_status
 
-    def capture_payment(self, govuk_payment, context):
+    def capture_govuk_payment(self, govuk_payment, context):
         """
         Captures and finalises a payment in status 'capturable' and sends a confirmation email to the user.
 

--- a/mtp_send_money/apps/send_money/payments.py
+++ b/mtp_send_money/apps/send_money/payments.py
@@ -101,11 +101,22 @@ class PaymentClient:
                 f"Unknown status: {govuk_payment['state']['status']}",
             )
 
-    def check_govuk_payment_status(self, payment, govuk_payment, context):
+    def should_be_automatically_captured(self, payment):
+        # TODO: work out if payment needs to be delayed and and save result via API
+        return True
+
+    def complete_payment_if_necessary(self, payment, govuk_payment, context):
         """
-        Returns a PaymentStatus for the GOV.UK payment govuk_payment.
+        Completes a payment if necessary and returns the resulting PaymentStatus.
+
         If the status is 'success' or 'capturable' and the MTP payment doesn't have any email,
         it updates the email field on record and sends an email to the user.
+
+        If the status is 'capturable' and the payment should be automatically captured, this method
+        captures and returns the new status.
+
+        If a payment is captured or it's found in success state for the first time, an email
+        to the sender is sent.
 
         :return: PaymentStatus for the GOV.UK payment govuk_payment
         :param payment: dict with MTP payment details as returned by the MTP API
@@ -127,37 +138,27 @@ class PaymentClient:
             )
 
         successfulish = govuk_status in [PaymentStatus.success, PaymentStatus.capturable]
+        # if nothing can be done, exist immediately
+        if not successfulish:
+            return govuk_status
+
         email = govuk_payment.get('email')
-        if successfulish and email and not payment.get('email'):
+        should_update_email = email and not payment.get('email')
+
+        if govuk_status == PaymentStatus.success and should_update_email:
+            # send successful email if it's the first time we get the sender's email address
+            send_notification(email, context)
+        elif govuk_status == PaymentStatus.capturable:
+            if self.should_be_automatically_captured(payment):
+                # capture payment and send successful email
+                govuk_status = self.capture_payment(govuk_payment, context)
+
+        # update email if necessary
+        if should_update_email:
             self.update_payment(payment['uuid'], {'email': email})
             payment['email'] = email
 
-            if govuk_status == PaymentStatus.success:
-                send_notification(email, context)
-
         return govuk_status
-
-    def check_govuk_payment_succeeded(self, payment, govuk_payment, context):
-        """
-        Returns True if the payment govuk_payment was successful.
-        If the govuk status is 'success' or 'capturable' and the MTP payment doesn't have any email,
-        it updates the email field on the record and sends an email to the user.
-
-        :return: True if the payment govuk_payment was successful, False otherwise
-        :raise GovUkPaymentStatusException: if govuk_payment is not in a finished state
-        :param payment: dict with MTP payment details as returned by the MTP API
-        :param govuk_payment: dict with GOV.UK payment details as returned by the GOV.UK Pay API
-        :param context: dict with extra variable to be used in constructing email body
-        """
-        govuk_status = self.check_govuk_payment_status(payment, govuk_payment, context)
-
-        if govuk_status is None:
-            return False
-
-        if not govuk_status.finished():
-            raise GovUkPaymentStatusException(f'Incomplete status: {govuk_status}')
-
-        return govuk_status == PaymentStatus.success
 
     def capture_payment(self, govuk_payment, context):
         """
@@ -167,7 +168,7 @@ class PaymentClient:
         """
         govuk_status = self.parse_govuk_payment_status(govuk_payment)
         if govuk_status is None or govuk_status.finished():
-            return
+            return govuk_status
 
         govuk_id = govuk_payment['payment_id']
         response = requests.post(
@@ -181,7 +182,9 @@ class PaymentClient:
         email = govuk_payment.get('email')
         send_notification(email, context)
 
-        govuk_payment['state']['status'] = PaymentStatus.success.name
+        govuk_status = PaymentStatus.success
+        govuk_payment['state']['status'] = govuk_status.name
+        return govuk_status
 
     def update_completed_payment(self, payment_ref, govuk_payment, success):
         card_details = govuk_payment.get('card_details') if govuk_payment else None

--- a/mtp_send_money/apps/send_money/tests/test_payments.py
+++ b/mtp_send_money/apps/send_money/tests/test_payments.py
@@ -1,10 +1,12 @@
+from unittest import mock
+
 from django.core import mail
 from django.test import override_settings
 from django.test.testcases import SimpleTestCase
+from mtp_common.test_utils import silence_logger
 from requests.exceptions import HTTPError
 import responses
 
-from send_money.exceptions import GovUkPaymentStatusException
 from send_money.payments import PaymentClient, PaymentStatus
 from send_money.tests import mock_auth
 from send_money.utils import api_url, govuk_url
@@ -48,8 +50,9 @@ class CapturePaymentTestCase(SimpleTestCase):
                 status=204,
             )
 
-            client.capture_payment(govuk_payment, context)
+            returned_status = client.capture_payment(govuk_payment, context)
 
+        self.assertEqual(returned_status, PaymentStatus.success)
         self.assertEqual(
             govuk_payment['state']['status'],
             PaymentStatus.success.name,
@@ -85,7 +88,8 @@ class CapturePaymentTestCase(SimpleTestCase):
             context = {}
 
             client = PaymentClient()
-            client.capture_payment(govuk_payment, context)
+            returned_status = client.capture_payment(govuk_payment, context)
+            self.assertEqual(returned_status, status)
 
             self.assertEqual(len(mail.outbox), 0)
 
@@ -97,7 +101,8 @@ class CapturePaymentTestCase(SimpleTestCase):
 
         govuk_payment = {}
         context = {}
-        client.capture_payment(govuk_payment, context)
+        returned_status = client.capture_payment(govuk_payment, context)
+        self.assertEqual(returned_status, None)
 
         self.assertEqual(len(mail.outbox), 0)
 
@@ -164,9 +169,9 @@ class CapturePaymentTestCase(SimpleTestCase):
     GOVUK_PAY_URL='https://pay.gov.local/v1',
     ENVIRONMENT='prod',  # because non-prod environments don't send to @outside.local
 )
-class CheckGovukPaymentStatusTestCase(SimpleTestCase):
+class CompletePaymentIfNecessaryTestCase(SimpleTestCase):
     """
-    Tests related to the check_govuk_payment_status method.
+    Tests related to the complete_payment_if_necessary method.
     """
 
     def test_success_status(self):
@@ -174,9 +179,9 @@ class CheckGovukPaymentStatusTestCase(SimpleTestCase):
         Test that if the govuk payment is in 'success' state and the MTP payment record
         doesn't have the email field filled in:
 
-        - the method returns PaymentStatus.success
         - the MTP payment record is patched with the email value
         - an confirmation email is sent to the sender
+        - the method returns PaymentStatus.success
         """
         client = PaymentClient()
 
@@ -204,19 +209,52 @@ class CheckGovukPaymentStatusTestCase(SimpleTestCase):
                 status=200,
             )
 
-            status = client.check_govuk_payment_status(payment, govuk_payment, context)
+            status = client.complete_payment_if_necessary(payment, govuk_payment, context)
 
         self.assertEqual(status, PaymentStatus.success)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(payment['email'], 'sender@example.com')
 
-    def test_capturable_status(self):
+    def test_success_status_with_email_already_set(self):
         """
-        Test that if the govuk payment is in 'capturable' state and the MTP payment record
-        doesn't have the email field filled in:
+        Test that if the govuk payment is in 'success' state and the MTP payment record
+        already has the email field filled in:
 
-        - the method returns PaymentStatus.capturable
+        - the method returns PaymentStatus.success
+
+        No email is sent as the email field was already filled in.
+        """
+        client = PaymentClient()
+
+        payment = {
+            'uuid': 'some-id',
+            'email': 'some-sender@example.com',
+        }
+        govuk_payment = {
+            'payment_id': 'payment-id',
+            'state': {
+                'status': PaymentStatus.success.name,
+            },
+            'email': 'sender@example.com',
+        }
+        context = {
+            'prisoner_name': 'John Doe',
+            'amount': 1700,
+        }
+
+        status = client.complete_payment_if_necessary(payment, govuk_payment, context)
+
+        self.assertEqual(status, PaymentStatus.success)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_capturable_status_not_automatically_captured(self):
+        """
+        Test that if the govuk payment is in 'capturable' state, the MTP payment record
+        doesn't have the email field filled in and the payment should not be automatically captured:
+
         - the MTP payment record is patched with the email value
+        - the method returns PaymentStatus.capturable
+        - no email is sent
         """
         client = PaymentClient()
 
@@ -234,7 +272,11 @@ class CheckGovukPaymentStatusTestCase(SimpleTestCase):
             'prisoner_name': 'John Doe',
             'amount': 1700,
         }
-        with responses.RequestsMock() as rsps:
+
+        with \
+                mock.patch.object(client, 'should_be_automatically_captured', return_value=False), \
+                responses.RequestsMock() as rsps:
+
             mock_auth(rsps)
 
             # API call related to updating the email address on the payment record
@@ -244,14 +286,67 @@ class CheckGovukPaymentStatusTestCase(SimpleTestCase):
                 status=200,
             )
 
-            status = client.check_govuk_payment_status(payment, govuk_payment, context)
+            status = client.complete_payment_if_necessary(payment, govuk_payment, context)
 
         self.assertEqual(status, PaymentStatus.capturable)
         self.assertEqual(len(mail.outbox), 0)
 
+    def test_capturable_status_automatically_captured(self):
+        """
+        Test that if the govuk payment is in 'capturable' state, the MTP payment record
+        doesn't have the email field filled in and the payment should be automatically captured:
+
+        - the method captures the payment
+        - the MTP payment record is patched with the email value
+        - a confirmation email is sent
+        - the method returns PaymentStatus.success
+        """
+        client = PaymentClient()
+
+        payment = {
+            'uuid': 'some-id',
+        }
+        govuk_payment = {
+            'payment_id': 'payment-id',
+            'state': {
+                'status': PaymentStatus.capturable.name,
+            },
+            'email': 'sender@example.com',
+        }
+        context = {
+            'prisoner_name': 'John Doe',
+            'amount': 1700,
+        }
+
+        with \
+                mock.patch.object(client, 'should_be_automatically_captured', return_value=True), \
+                responses.RequestsMock() as rsps:
+
+            mock_auth(rsps)
+
+            rsps.add(
+                rsps.POST,
+                govuk_url(f'/payments/{govuk_payment["payment_id"]}/capture/'),
+                status=204,
+            )
+
+            # API call related to updating the email address on the payment record
+            rsps.add(
+                rsps.PATCH,
+                api_url(f'/payments/{payment["uuid"]}/'),
+                status=200,
+            )
+
+            status = client.complete_payment_if_necessary(payment, govuk_payment, context)
+
+        self.assertEqual(status, PaymentStatus.success)
+        self.assertEqual(len(mail.outbox), 1)
+
     def test_dont_send_email(self):
         """
-        Test that if the status of govuk payment != 'success', the method doesn't send any email.
+        Test that the method only sends any email if:
+        - the govuk payment status is 'success' and the MTP payment didn't have the email field set
+        - the govuk payment status is 'capturable' and the payment should be automatically captured.
         """
         client = PaymentClient()
 
@@ -266,7 +361,11 @@ class CheckGovukPaymentStatusTestCase(SimpleTestCase):
             if status != PaymentStatus.success
         ]
 
-        with responses.RequestsMock() as rsps:
+        with \
+                mock.patch.object(client, 'should_be_automatically_captured', return_value=False), \
+                responses.RequestsMock() as rsps, \
+                silence_logger():
+
             # the 'capturable' status triggers an update on payment.email
             mock_auth(rsps)
             rsps.add(
@@ -287,7 +386,7 @@ class CheckGovukPaymentStatusTestCase(SimpleTestCase):
                     },
                     'email': 'sender@example.com',
                 }
-                actual_status = client.check_govuk_payment_status(payment, govuk_payment, context)
+                actual_status = client.complete_payment_if_necessary(payment, govuk_payment, context)
 
                 self.assertEqual(actual_status, status)
                 self.assertEqual(len(mail.outbox), 0)
@@ -302,128 +401,7 @@ class CheckGovukPaymentStatusTestCase(SimpleTestCase):
         payment = {}
         govuk_payment = {}
         context = {}
-        status = client.check_govuk_payment_status(payment, govuk_payment, context)
+        status = client.complete_payment_if_necessary(payment, govuk_payment, context)
 
         self.assertEqual(status, None)
         self.assertEqual(len(mail.outbox), 0)
-
-
-@override_settings(
-    GOVUK_PAY_URL='https://pay.gov.local/v1',
-    ENVIRONMENT='prod',  # because non-prod environments don't send to @outside.local
-)
-class CheckGovukPaymentSucceededTestCase(SimpleTestCase):
-    """
-    Tests related to the check_govuk_payment_succeeded method.
-    """
-
-    def test_returns_true_if_payment_succeeded(self):
-        """
-        Test that if the govuk payment is in 'success' state and the MTP payment record
-        doesn't have the email field filled in:
-
-        - the method returns True
-        - the MTP payment record is patched with the email value
-        - an confirmation email is sent to the sender
-        """
-        client = PaymentClient()
-
-        payment = {
-            'uuid': 'some-id',
-        }
-        govuk_payment = {
-            'payment_id': 'payment-id',
-            'state': {
-                'status': PaymentStatus.success.name,
-            },
-            'email': 'sender@example.com',
-        }
-        context = {
-            'prisoner_name': 'John Doe',
-            'amount': 1700,
-        }
-        with responses.RequestsMock() as rsps:
-            mock_auth(rsps)
-
-            # API call related to updating the email address on the payment record
-            rsps.add(
-                rsps.PATCH,
-                api_url(f'/payments/{payment["uuid"]}/'),
-                status=200,
-            )
-
-            succeeded = client.check_govuk_payment_succeeded(payment, govuk_payment, context)
-
-        self.assertEqual(succeeded, True)
-        self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(payment['email'], 'sender@example.com')
-
-    def test_returns_false_if_payment_failed(self):
-        """
-        Test that if the govuk payment is in a finished non-successful state, the method returns
-        False and no email is sent.
-        """
-        client = PaymentClient()
-
-        payment = {
-            'uuid': 'some-id',
-        }
-        context = {}
-
-        statuses = [PaymentStatus.error, PaymentStatus.failed, PaymentStatus.cancelled]
-        for status in statuses:
-            govuk_payment = {
-                'payment_id': 'payment-id',
-                'state': {
-                    'status': status.name,
-                },
-                'email': 'sender@example.com',
-            }
-
-        succeeded = client.check_govuk_payment_succeeded(payment, govuk_payment, context)
-
-        self.assertEqual(succeeded, False)
-        self.assertEqual(len(mail.outbox), 0)
-
-    def test_returns_false_if_govukpayment_is_falsy(self):
-        """
-        Test that if the passed in govuk payment dict is falsy, the method returns False and
-        doesn't send any email.
-        """
-        client = PaymentClient()
-
-        payment = {}
-        govuk_payment = {}
-        context = {}
-        status = client.check_govuk_payment_succeeded(payment, govuk_payment, context)
-
-        self.assertEqual(status, False)
-        self.assertEqual(len(mail.outbox), 0)
-
-    def test_raise_exception_if_status_is_incomplete(self):
-        """
-        Test that if the govuk payment is in a finished non-successful state, the method returns
-        False and no email is sent.
-        """
-        client = PaymentClient()
-
-        payment = {
-            'uuid': 'some-id',
-        }
-        context = {}
-
-        incomplete_statuses = [
-            status
-            for status in PaymentStatus
-            if not status.finished()
-        ]
-        for status in incomplete_statuses:
-            govuk_payment = {
-                'payment_id': 'payment-id',
-                'state': {
-                    'status': status.name,
-                }
-            }
-
-            with self.assertRaises(GovUkPaymentStatusException):
-                client.check_govuk_payment_succeeded(payment, govuk_payment, context)

--- a/mtp_send_money/apps/send_money/tests/test_payments.py
+++ b/mtp_send_money/apps/send_money/tests/test_payments.py
@@ -16,9 +16,9 @@ from send_money.utils import api_url, govuk_url
     GOVUK_PAY_URL='https://pay.gov.local/v1',
     ENVIRONMENT='prod',  # because non-prod environments don't send to @outside.local
 )
-class CapturePaymentTestCase(SimpleTestCase):
+class CaptureGovukPaymentTestCase(SimpleTestCase):
     """
-    Tests related to the capture_payment method.
+    Tests related to the capture_govuk_payment method.
     """
 
     def test_capture(self):
@@ -50,7 +50,7 @@ class CapturePaymentTestCase(SimpleTestCase):
                 status=204,
             )
 
-            returned_status = client.capture_payment(govuk_payment, context)
+            returned_status = client.capture_govuk_payment(govuk_payment, context)
 
         self.assertEqual(returned_status, PaymentStatus.success)
         self.assertEqual(
@@ -65,7 +65,7 @@ class CapturePaymentTestCase(SimpleTestCase):
         )
 
         # try to capture the payment again, nothing should happen
-        client.capture_payment(govuk_payment, context)
+        client.capture_govuk_payment(govuk_payment, context)
         self.assertEqual(len(mail.outbox), 1)
 
     def test_do_nothing_if_payment_in_finished_state(self):
@@ -88,7 +88,7 @@ class CapturePaymentTestCase(SimpleTestCase):
             context = {}
 
             client = PaymentClient()
-            returned_status = client.capture_payment(govuk_payment, context)
+            returned_status = client.capture_govuk_payment(govuk_payment, context)
             self.assertEqual(returned_status, status)
 
             self.assertEqual(len(mail.outbox), 0)
@@ -101,7 +101,7 @@ class CapturePaymentTestCase(SimpleTestCase):
 
         govuk_payment = {}
         context = {}
-        returned_status = client.capture_payment(govuk_payment, context)
+        returned_status = client.capture_govuk_payment(govuk_payment, context)
         self.assertEqual(returned_status, None)
 
         self.assertEqual(len(mail.outbox), 0)
@@ -128,7 +128,7 @@ class CapturePaymentTestCase(SimpleTestCase):
             )
 
             with self.assertRaises(HTTPError) as e:
-                client.capture_payment(govuk_payment, context)
+                client.capture_govuk_payment(govuk_payment, context)
 
             self.assertEqual(
                 e.exception.response.status_code,
@@ -157,7 +157,7 @@ class CapturePaymentTestCase(SimpleTestCase):
             )
 
             with self.assertRaises(HTTPError) as e:
-                client.capture_payment(govuk_payment, context)
+                client.capture_govuk_payment(govuk_payment, context)
 
             self.assertEqual(
                 e.exception.response.status_code,

--- a/mtp_send_money/apps/send_money/views.py
+++ b/mtp_send_money/apps/send_money/views.py
@@ -436,7 +436,7 @@ class DebitCardConfirmationView(TemplateView):
                 govuk_payment = payment_client.get_govuk_payment(govuk_id)
 
                 # check payment and send confirmation email if successful
-                self.status = payment_client.check_govuk_payment_status(
+                self.status = payment_client.complete_payment_if_necessary(
                     payment, govuk_payment, kwargs
                 )
 


### PR DESCRIPTION
This changes the payment confirmation view and the periodic update_incomplete_payments task to automatically capture payments found in `capturable` status.

A TODO was added to update the payment (e.g. saving card details) before checking if it has to to be delayed.

The overall journey has not changed as we are still not passing yet `"delayed_capture": true`.