### PR TITLE
Remove template-deploy artefacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,18 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
+          name: Log into ECR
+          command: |
+            source /tmp/mtp-env.sh
+            $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
+      - run:
           name: Build docker image
           command: |
             source /tmp/mtp-env.sh
+            docker pull ${registry}:base-web
+            docker tag ${registry}:base-web base-web
             docker build \
-              --pull --force-rm \
+              --force-rm \
               --build-arg APP_GIT_COMMIT=${CIRCLE_SHA1} \
               --build-arg APP_GIT_BRANCH=${CIRCLE_BRANCH} \
               --build-arg APP_BUILD_TAG=${tag} \
@@ -49,7 +56,6 @@ jobs:
           name: Push docker image
           command: |
             source /tmp/mtp-env.sh
-            $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
             echo "Pushing ${tag} to ECR"
             docker tag ${tag} ${registry}:${tag}
             docker push ${registry}:${tag}
@@ -58,6 +64,10 @@ jobs:
               docker tag ${tag} ${registry}:${app}
               docker push ${registry}:${app}
             fi
+      - run:
+          name: Log out of ECR
+          command: |
+            source /tmp/mtp-env.sh
             docker logout ${ECR_ENDPOINT}
       - run:
           name: Deploy to test

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ministryofjustice/prisoner-money

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,52 +1,12 @@
-FROM buildpack-deps:bionic
-
-# setup UK environment and install libraries and python
-RUN set -ex; \
-  apt-get update \
-  && \
-  DEBIAN_FRONTEND=noninteractive apt-get install \
-  -y --no-install-recommends --no-install-suggests \
-  -o DPkg::Options::=--force-confdef \
-  locales tzdata \
-  && \
-  echo en_GB.UTF-8 UTF-8 > /etc/locale.gen \
-  && \
-  locale-gen \
-  && \
-  rm /etc/localtime \
-  && \
-  ln -s /usr/share/zoneinfo/Europe/London /etc/localtime \
-  && \
-  dpkg-reconfigure --frontend noninteractive tzdata \
-  && \
-  DEBIAN_FRONTEND=noninteractive apt-get install \
-  -y --no-install-recommends --no-install-suggests \
-  -o DPkg::Options::=--force-confdef \
-  software-properties-common build-essential \
-  gettext rsync libssl1.0-dev \
-  python3-all-dev python3-setuptools python3-pip python3-wheel python3-venv \
-  nodejs nodejs-dev node-gyp npm \
-  chromium-browser \
-  && \
-  rm -rf /var/lib/apt/lists/* \
-  && \
-  npm set progress=false
-ENV LANG=en_GB.UTF-8
-ENV TZ=Europe/London
+FROM base-web
 
 # pre-create directories
-WORKDIR /app
 RUN set -ex; mkdir -p \
   mtp_send_money/assets \
   mtp_send_money/assets-static \
   static \
   media \
   spooler
-
-# install virtual environment
-RUN set -ex; \
-  /usr/bin/python3 -m venv venv && \
-  venv/bin/pip install -U setuptools pip wheel
 
 # cache python packages, unless requirements change
 COPY ./requirements requirements
@@ -56,8 +16,6 @@ RUN venv/bin/pip install -r requirements/docker.txt
 COPY . /app
 RUN set -ex; \
   venv/bin/python run.py --requirements-file requirements/docker.txt build \
-  && \
-  test $(id -u www-data) = 33 \
   && \
   chown -R www-data:www-data /app
 USER 33

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
-# Send Money to Prisoners
+# Send money to someone in prison
 
-[![Dependency Status](https://img.shields.io/david/ministryofjustice/money-to-prisoners-send-money.svg?style=flat-square&label=NPM%20deps)](https://david-dm.org/ministryofjustice/money-to-prisoners-send-money)
-[![devDependency Status](https://img.shields.io/david/dev/ministryofjustice/money-to-prisoners-send-money.svg?style=flat-square&label=NPM%20devDeps)](https://david-dm.org/ministryofjustice/money-to-prisoners-send-money#info=devDependencies)
-
-Citizen-facing public site for Money to Prisoners
-
+Citizen-facing site for Money to Prisoners (MTP).
+Part of the Prisoner Money suite of apps.
 
 ## Running locally
 
@@ -12,37 +9,37 @@ It's recommended that you use a python virtual environment to isolate each appli
 Please call this `venv` and make sure it's in the root folder of this application so that
 `mtp_common.test_utils.code_style.CodeStyleTestCase` and the build tasks can find it.
 
-
 In order to run the application locally, it is necessary to have the API running.
 Please refer to the [money-to-prisoners-api](https://github.com/ministryofjustice/money-to-prisoners-api/) repository.
 
-Once the API is running locally, run
+Once the API has started locally, run
 
 ```
+./run.py serve
+# or
 ./run.py start
 ```
 
-This will build everything (which will initially take a while) and run
-the local server at [http://localhost:8004/](http://localhost:8004/).
-
+This will build everything and run the local server at [http://localhost:8004/](http://localhost:8004/).
 
 ### Alternative: Docker
 
 In order to run a server that's exactly similar to the production machines,
-you need to have [Docker](https://www.docker.com/docker-toolbox) installed. Run
+you need to have [Docker](https://www.docker.com/products/developer-tools) installed. Run
 
 ```
 ./run.py local_docker
 ```
 
-and you should eventually be able to connect to the local server.
+and you should be able to connect to the local server.
 
 ## Developing
+
+[![CircleCI](https://circleci.com/gh/ministryofjustice/money-to-prisoners-send-money.svg?style=svg)](https://circleci.com/gh/ministryofjustice/money-to-prisoners-send-money)
 
 With the `./run.py` command, you can run a browser-sync server, and get the assets
 to automatically recompile when changes are made, run `./run.py serve` instead of
 `./run.py start`. The server is then available at the URL indicated.
-
 
 ```
 ./run.py test
@@ -61,9 +58,11 @@ python_dependencies --common-path [path]
 
 Update translation files with `./run.py make_messages` – you need to do this every time any translatable text is updated.
 
-Pull updates from Transifex with ``./run.py translations --pull``. You'll need to update translation files afterwards and manually check that the merges occurred correctly.
+Pull updates from Transifex with `./run.py translations --pull`.
+You'll need to update translation files afterwards and manually check that the merges occurred correctly.
 
-Push latest English to Transifex with ``./run.py translations --push``. NB: you should pull updates before pushing to merge correctly.
+Push latest English to Transifex with `./run.py translations --push`.
+NB: you should pull updates before pushing to merge correctly.
 
 ## Deploying
 

--- a/mtp_send_money/settings/base.py
+++ b/mtp_send_money/settings/base.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = (
 PROJECT_APPS = (
     'anymail',
     'mtp_common',
+    'mtp_common.metrics',
     'send_money',
     'zendesk_tickets'
 )
@@ -78,6 +79,9 @@ MIDDLEWARE = (
 
 HEALTHCHECKS = []
 AUTODISCOVER_HEALTHCHECKS = True
+
+METRICS_USER = os.environ.get('METRICS_USER', 'prom')
+METRICS_PASS = os.environ.get('METRICS_PASS', 'prom')
 
 # security tightening
 # some overridden in prod/docker settings where SSL is ensured

--- a/mtp_send_money/settings/base.py
+++ b/mtp_send_money/settings/base.py
@@ -1,9 +1,3 @@
-"""
-Django settings for mtp_send_money project.
-
-For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.9/ref/settings/
-"""
 from decimal import Decimal
 from functools import partial
 import os

--- a/mtp_send_money/settings/base.py
+++ b/mtp_send_money/settings/base.py
@@ -9,6 +9,7 @@ from functools import partial
 import os
 from os.path import abspath, dirname, join
 import sys
+from urllib.parse import urljoin
 
 BASE_DIR = dirname(dirname(abspath(__file__)))
 sys.path.insert(0, os.path.join(BASE_DIR, 'apps'))
@@ -27,7 +28,27 @@ SECRET_KEY = 'CHANGE_ME'
 ALLOWED_HOSTS = []
 
 START_PAGE_URL = os.environ.get('START_PAGE_URL', 'https://www.gov.uk/send-prisoner-money')
-SITE_URL = os.environ.get('SITE_URL', 'http://localhost:8004')
+CASHBOOK_URL = (
+    f'https://{os.environ["PUBLIC_CASHBOOK_HOST"]}'
+    if os.environ.get('PUBLIC_CASHBOOK_HOST')
+    else 'http://localhost:8001'
+)
+BANK_ADMIN_URL = (
+    f'https://{os.environ["PUBLIC_BANK_ADMIN_HOST"]}'
+    if os.environ.get('PUBLIC_BANK_ADMIN_HOST')
+    else 'http://localhost:8002'
+)
+NOMS_OPS_URL = (
+    f'https://{os.environ["PUBLIC_NOMS_OPS_HOST"]}'
+    if os.environ.get('PUBLIC_NOMS_OPS_HOST')
+    else 'http://localhost:8003'
+)
+SEND_MONEY_URL = (
+    f'https://{os.environ["PUBLIC_SEND_MONEY_HOST"]}'
+    if os.environ.get('PUBLIC_SEND_MONEY_HOST')
+    else 'http://localhost:8004'
+)
+SITE_URL = SEND_MONEY_URL
 
 # Application definition
 INSTALLED_APPS = (
@@ -100,6 +121,7 @@ STATICFILES_DIRS = [
     get_project_dir('assets'),
     get_project_dir('assets-static'),
 ]
+PUBLIC_STATIC_URL = urljoin(SEND_MONEY_URL, STATIC_URL)
 
 TEMPLATES = [
     {

--- a/mtp_send_money/settings/base.py
+++ b/mtp_send_money/settings/base.py
@@ -217,31 +217,14 @@ TEST_RUNNER = 'mtp_common.test_utils.runner.TestRunner'
 # authentication
 SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
 MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
-
 AUTHENTICATION_BACKENDS = (
     'mtp_common.auth.backends.MojBackend',
 )
 
 
-def find_api_url():
-    import socket
-    import subprocess
-
-    api_port = int(os.environ.get('API_PORT', '8000'))
-    try:
-        host_machine_ip = subprocess.check_output(['docker-machine', 'ip', 'default'],
-                                                  stderr=subprocess.DEVNULL)
-        host_machine_ip = host_machine_ip.decode('ascii').strip()
-        with socket.socket() as sock:
-            sock.connect((host_machine_ip, api_port))
-    except (subprocess.CalledProcessError, OSError):
-        host_machine_ip = 'localhost'
-    return 'http://%s:%s' % (host_machine_ip, api_port)
-
-
 API_CLIENT_ID = 'send-money'
 API_CLIENT_SECRET = os.environ.get('API_CLIENT_SECRET', 'send-money')
-API_URL = os.environ.get('API_URL', find_api_url())
+API_URL = os.environ.get('API_URL', 'http://localhost:8000')
 
 SHARED_API_USERNAME = os.environ.get('SHARED_API_USERNAME', 'send-money')
 SHARED_API_PASSWORD = os.environ.get('SHARED_API_PASSWORD', 'send-money')

--- a/mtp_send_money/urls.py
+++ b/mtp_send_money/urls.py
@@ -6,6 +6,7 @@ from django.views.decorators.cache import cache_control
 from django.views.generic.base import RedirectView
 from django.views.i18n import JavaScriptCatalog
 from moj_irat.views import HealthcheckView, PingJsonView
+from mtp_common.metrics.views import metrics_view
 
 from send_money.utils import make_response_cacheable
 from send_money.views_misc import CookiesView, SitemapXMLView, robots_txt_view
@@ -37,6 +38,7 @@ urlpatterns += [
         version_number_key='APP_BUILD_TAG',
     ), name='ping_json'),
     url(r'^healthcheck.json$', HealthcheckView.as_view(), name='healthcheck_json'),
+    url(r'^metrics.txt$', metrics_view, name='prometheus_metrics'),
 
     url(r'^robots.txt$', robots_txt_view),
     url(r'^sitemap.xml$', SitemapXMLView.as_view(), name='sitemap_xml'),

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=9.13,<9.14
+money-to-prisoners-common[testing]>=9.15,<9.16

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=9.13,<9.14
+money-to-prisoners-common[monitoring]>=9.15,<9.16
 
 uWSGI==2.0.18


### PR DESCRIPTION
- As apps are now able to discover each other, many environment variables are now redundant so they can be removed
- Apps now use base Docker images built by this repository (pulling from ECR or building locally) – this speeds up builds and ensures they have the same base OS
- Add prometheus service monitors for all apps
- Depends on [mtp-deploy#282](https://github.com/ministryofjustice/money-to-prisoners-deploy/pull/282)