### PR TITLE
Create Payment on hold page and redesign confirmation pages

### DIFF
--- a/mtp_send_money/apps/send_money/payments.py
+++ b/mtp_send_money/apps/send_money/payments.py
@@ -152,6 +152,9 @@ class PaymentClient:
             if self.should_be_automatically_captured(payment):
                 # capture payment and send successful email
                 govuk_status = self.capture_govuk_payment(govuk_payment, context)
+            elif 'email' in payment_attr_updates:
+                # TODO send capturable email
+                pass
         elif govuk_status == PaymentStatus.success:
             # TODO consider updating other attrs using `get_completion_payment_attr_updates`
             email = govuk_payment.get('email')

--- a/mtp_send_money/apps/send_money/views.py
+++ b/mtp_send_money/apps/send_money/views.py
@@ -432,6 +432,8 @@ class DebitCardConfirmationView(TemplateView):
     def get_template_names(self):
         if self.status == PaymentStatus.success:
             return ['send_money/debit-card-confirmation.html']
+        if self.status == PaymentStatus.capturable:
+            return ['send_money/debit-card-on-hold.html']
         return ['send_money/debit-card-failure.html']
 
     def dispatch(self, request, *args, **kwargs):
@@ -460,6 +462,7 @@ class DebitCardConfirmationView(TemplateView):
 
             kwargs.update({
                 'prisoner_name': payment['recipient_name'],
+                'prisoner_number': payment['prisoner_number'],
                 'amount': decimal.Decimal(payment['amount']) / 100,
             })
 

--- a/mtp_send_money/assets-src/stylesheets/app.scss
+++ b/mtp_send_money/assets-src/stylesheets/app.scss
@@ -18,11 +18,41 @@
 // Govuk elements overrides
 
 .govuk-box-highlight {
+  padding: 2em;
+
   p, strong {
-    font-size: 18px;
+    @include core-36;
+  }
+
+  p {
+    margin-bottom: 2px;
+  }
+
+  strong {
+    font-weight: 700;
+  }
+
+  h1 {
+    margin-top: 0;
+    margin-bottom: 0.6em;
   }
 
   h2 {
     margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  &.mtp-box-highlight-info {
+    background: $govuk-blue;
+  }
+
+  &.mtp-box-highlight-success {
+    background: $green;
+  }
+
+  @media print {
+    background: none;
+    border: 2px solid $border-colour;
+    color: $text-colour;
   }
 }

--- a/mtp_send_money/assets-src/stylesheets/elements/_typography.scss
+++ b/mtp_send_money/assets-src/stylesheets/elements/_typography.scss
@@ -16,17 +16,3 @@ ol > li {
 .list {
   padding-left: 35px;
 }
-
-.govuk-box-highlight {
-  padding: .1em 0 1em;
-
-  p {
-    margin-bottom: 2px;
-  }
-
-  @media print {
-    background: none;
-    border: 2px solid $border-colour;
-    color: $text-colour;
-  }
-}

--- a/mtp_send_money/templates/send_money/bank-transfer-reference.html
+++ b/mtp_send_money/templates/send_money/bank-transfer-reference.html
@@ -7,8 +7,8 @@
 
 {% block inner_content %}
 
-  <div class="govuk-box-highlight">
-    <h1 class="heading-medium">{% trans 'Your prisoner reference:' %}</h1>
+  <div class="govuk-box-highlight mtp-box-highlight-success">
+    <h1 class="heading-xlarge">{% trans 'Your prisoner reference is' %}</h1>
     <h2 class="heading-large">{{ bank_transfer_reference }}</h2>
     <p>{% trans 'Use this reference to make your bank transfer' %}</p>
   </div>
@@ -30,59 +30,63 @@
     </p>
   </form>
 
-  <section>
-    <h2 class="heading-medium">{% trans 'Now you can make the bank transfer' %}</h2>
-    <ol class="list list-number">
-      <li>
-        {% trans 'Log into your online banking account, mobile banking app or use your telephone banking, as normal.' %}
-      </li>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <section>
+        <h2 class="heading-medium">{% trans 'Now you can make the bank transfer' %}</h2>
+        <ol class="list list-number">
+          <li>
+            {% trans 'Log into your online banking account, mobile banking app or use your telephone banking, as normal.' %}
+          </li>
 
-      <li>
-        {% trans 'Copy and paste these details into the transfer:' %}
-        <div class="mtp-account panel panel-border-wide">
-          <table>
-            <tbody>
-              <tr>
-                <th>{% trans 'Account number:' %}</th>
-                <td>{{ account_number }}</td>
-              </tr>
-              <tr>
-                <th>{% trans 'Sort code:'%}</th>
-                <td>{{ sort_code }}</td>
-              </tr>
-              <tr>
-                <th>{% trans 'Reference:' %}</th>
-                <td>{{ bank_transfer_reference }}</td>
-              </tr>
-              <tr>
-                <th>{% trans 'Payee/Name:' %}</th>
-                <td>{{ bank_transfer_reference }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <p>
-          {% trans 'All prisons share this bank account.' %}
-          {% trans 'Please use your prisoner reference to make sure the money goes to the right prisoner.' %}
-        </p>
-        <p>
-          <strong>{% trans 'Remember:'%}</strong>
-          {% trans 'You can’t do a bank transfer in-branch and you must use a UK bank account.' %}
-        </p>
-      </li>
+          <li>
+            {% trans 'Copy and paste these details into the transfer:' %}
+            <div class="mtp-account panel panel-border-wide">
+              <table>
+                <tbody>
+                  <tr>
+                    <th>{% trans 'Account number:' %}</th>
+                    <td>{{ account_number }}</td>
+                  </tr>
+                  <tr>
+                    <th>{% trans 'Sort code:'%}</th>
+                    <td>{{ sort_code }}</td>
+                  </tr>
+                  <tr>
+                    <th>{% trans 'Reference:' %}</th>
+                    <td>{{ bank_transfer_reference }}</td>
+                  </tr>
+                  <tr>
+                    <th>{% trans 'Payee/Name:' %}</th>
+                    <td>{{ bank_transfer_reference }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p>
+              {% trans 'All prisons share this bank account.' %}
+              {% trans 'Please use your prisoner reference to make sure the money goes to the right prisoner.' %}
+            </p>
+            <p>
+              <strong>{% trans 'Remember:'%}</strong>
+              {% trans 'You can’t do a bank transfer in-branch and you must use a UK bank account.' %}
+            </p>
+          </li>
 
-      <li>
-        {% trans 'The money should take up to 3 working days to reach the prisoner’s account.' %}
-        {% trans 'No money is processed at weekends or bank holidays.' %}
-      </li>
-    </ol>
-    <p>
-      {% url 'send_money:help_bank_transfer' as help_url %}
-      {% url 'submit_ticket' as ticket_url %}
-      {% blocktrans trimmed %}
-        <a href="{{ help_url }}">Find further help</a> on how to use the service or <a href="{{ ticket_url }}">contact us</a>.
-      {% endblocktrans %}
-    </p>
-  </section>
+          <li>
+            {% trans 'The money should take up to 3 working days to reach the prisoner’s account.' %}
+            {% trans 'No money is processed at weekends or bank holidays.' %}
+          </li>
+        </ol>
+        <p>
+          {% url 'send_money:help_bank_transfer' as help_url %}
+          {% url 'submit_ticket' as ticket_url %}
+          {% blocktrans trimmed %}
+            <a href="{{ help_url }}">Find further help</a> on how to use the service or <a href="{{ ticket_url }}">contact us</a>.
+          {% endblocktrans %}
+        </p>
+      </section>
+    </div>
+  </div>
 
 {% endblock %}

--- a/mtp_send_money/templates/send_money/debit-card-confirmation.html
+++ b/mtp_send_money/templates/send_money/debit-card-confirmation.html
@@ -6,8 +6,8 @@
 
 {% block inner_content %}
 
-  <div class="govuk-box-highlight">
-    <h1 class="heading-large">{% trans 'Payment successful' %}</h1>
+  <div class="govuk-box-highlight mtp-box-highlight-success">
+    <h1 class="heading-xlarge">{% trans 'Payment successful' %}</h1>
     <p>{% trans 'Your confirmation number is' %}<p>
     <strong>{{ short_payment_ref }}</strong>
   </div>
@@ -16,39 +16,44 @@
     <a class="mtp-print-reference" href="#">{% trans 'Print this page' %}</a>
   </div>
 
-  <h2 class="heading-medium">{% trans 'Payment summary' %}</h2>
-  <table class="mtp-check-table">
-    <tbody>
-      <tr>
-        <th>{% trans 'Payment to' %}:</th>
-        <td>{{ prisoner_name }}</td>
-      </tr>
-      <tr>
-        <th>{% trans 'Payment amount' %}:</th>
-        <td>{{ amount|currency_format }}</td>
-      </tr>
-      <tr>
-        <th>{% trans 'Date payment made' %}:</th>
-        <td>{% now 'd/m/Y' %}</td>
-      </tr>
-      <tr>
-        <th>{% trans 'Confirmation number' %}:</th>
-        <td>{{ short_payment_ref }}</td>
-      </tr>
-    </tbody>
-  </table>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <div class="mtp-account panel panel-border-wide">
+        <table>
+          <tbody>
+            <tr>
+              <th>{% trans 'Payment to' %}:</th>
+              <td>{{ prisoner_name }}</td>
+            </tr>
+            <tr>
+              <th>{% trans 'Amount' %}:</th>
+              <td>{{ amount|currency_format }}</td>
+            </tr>
+            <tr>
+              <th>{% trans 'Date payment made' %}:</th>
+              <td>{% now 'd/m/Y' %}</td>
+            </tr>
+            <tr>
+              <th>{% trans 'Confirmation number' %}:</th>
+              <td>{{ short_payment_ref }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
 
-  <h2 class="heading-medium">{% trans 'What happens next' %}</h2>
-  <ol class="list list-number">
-    <li>
-      {% trans 'We’ll email you a copy of this confirmation page.' %}
-      {% trans 'Please check your spam folder.' %}
-    </li>
-    <li>{% trans 'The money will arrive in the prisoner’s account in up to 3 working days.' %}</li>
-    <li>{% trans 'You’ll get a further email when the prisoner’s account has been credited to confirm your money has arrived.' %}</li>
-  </ol>
+      <h2 class="heading-medium">{% trans 'What happens next' %}</h2>
+      <ol class="list list-number">
+        <li>
+          {% trans 'We’ll email you a copy of this confirmation page.' %}
+          {% trans 'Please check your spam folder.' %}
+        </li>
+        <li>{% trans 'Money usually takes less than 3 working days to reach a prisoner’s account, but may take longer.' %}</li>
+        <li>{% trans 'You’ll get a further email when the prisoner’s account has been credited to confirm your money has arrived.' %}</li>
+      </ol>
 
-  <p>
-    <a href="https://www.gov.uk/done/send-prisoner-money">{% trans 'Take a moment to rate this service' %}</a>
-  </p>
+      <p>
+        <a href="https://www.gov.uk/done/send-prisoner-money">{% trans 'Take a moment to rate this service' %}</a> {% trans '(takes 30 seconds)' %}
+      </p>
+    </div>
+  </div>
 {% endblock %}

--- a/mtp_send_money/templates/send_money/debit-card-on-hold.html
+++ b/mtp_send_money/templates/send_money/debit-card-on-hold.html
@@ -1,0 +1,53 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load send_money %}
+
+{% block page_title %}{% trans 'Payment on hold' %} – {{ block.super }}{% endblock %}
+
+{% block inner_content %}
+
+  <div class="govuk-box-highlight mtp-box-highlight-info">
+    <h1 class="heading-xlarge">{% trans 'This payment has been put on hold for up to 5 days' %}</h1>
+    <p>{% trans 'Reference:' %} <strong>{{ short_payment_ref }}</strong></p>
+  </div>
+
+  <div class="print-hidden mtp-reference-actions">
+    <a class="mtp-print-reference" href="#">{% trans 'Print this page' %}</a>
+  </div>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <div class="mtp-account panel panel-border-wide">
+        <table>
+          <tbody>
+            <tr>
+              <th>{% trans 'Payment to' %}:</th>
+              <td>{{ prisoner_name }} ( {{ prisoner_number }})</td>
+            </tr>
+            <tr>
+              <th>{% trans 'Amount' %}:</th>
+              <td>{{ amount|currency_format }}</td>
+            </tr>
+            <tr>
+              <th>{% trans 'Date' %}:</th>
+              <td>{% now 'd/m/Y' %}</td>
+            </tr>
+            <tr>
+              <th>{% trans 'Reference' %}:</th>
+              <td>{{ short_payment_ref }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p>{% trans 'To maintain a high level of prison safety we do regular security checks.' %}</p>
+      <p>{% trans 'We’ll email you a payment update as soon as we can and are sorry for any inconvenience this may cause.' %}</p>
+      <p>
+        {% url 'submit_ticket' as ticket_url %}
+        {% blocktrans trimmed %}
+          If you’re worried about a prisoner, <a href="{{ ticket_url }}">email us</a> and we can inform the prison.
+        {% endblocktrans %}
+      </p>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This:
- redesigns the card payment confirmation page
- redesigns the bank transfer "confirmation" page
- adds a new page for payments on hold

### Bank transfer
<img width="984" alt="Z payment bank transfer" src="https://user-images.githubusercontent.com/178865/69881554-4f820600-12c5-11ea-886d-ebe3ae62bcee.png">

### Card  payment
<img width="984" alt="Z  payment success" src="https://user-images.githubusercontent.com/178865/69881569-5ad53180-12c5-11ea-9b70-59baeecf0389.png">

### Payment on hold
<img width="989" alt="Z payment on hold" src="https://user-images.githubusercontent.com/178865/69881581-63c60300-12c5-11ea-8def-7423f2f54fc7.png">
