### PR TITLE
Payment on hold email

### DIFF
--- a/mtp_send_money/apps/send_money/mail.py
+++ b/mtp_send_money/apps/send_money/mail.py
@@ -1,0 +1,52 @@
+from django.conf import settings
+from django.urls import reverse
+from django.utils.translation import gettext
+from mtp_common.tasks import send_email
+
+from send_money.utils import site_url
+
+
+def _send_notification_email(email, template_name, subject, tags, context):
+    context.update({
+        'site_url': settings.START_PAGE_URL,
+        'feedback_url': site_url(reverse('submit_ticket')),
+        'help_url': site_url(reverse('send_money:help')),
+    })
+    send_email(
+        email,
+        f'send_money/email/{template_name}.txt',
+        gettext('Send money to someone in prison: %(subject)s' % {'subject': subject}),
+        context=context,
+        html_template=f'send_money/email/{template_name}.html',
+        anymail_tags=tags,
+    )
+
+
+def send_email_for_card_payment_confirmation(email, context):
+    _send_notification_email(
+        email,
+        'debit-card-confirmation',
+        gettext('your payment was successful'),
+        ['dc-received'],
+        context,
+    )
+
+
+def send_email_for_card_payment_on_hold(email, context):
+    _send_notification_email(
+        email,
+        'debit-card-on-hold',
+        gettext('your payment has been put on hold'),
+        ['dc-on-hold'],
+        context,
+    )
+
+
+def send_email_for_bank_transfer_reference(email, context):
+    _send_notification_email(
+        email,
+        'bank-transfer-reference',
+        gettext('Your prisoner reference is %(bank_transfer_reference)s' % context),
+        ['bt-reference'],
+        context,
+    )

--- a/mtp_send_money/apps/send_money/payments.py
+++ b/mtp_send_money/apps/send_money/payments.py
@@ -104,7 +104,7 @@ class PaymentClient:
                 f"Unknown status: {govuk_payment['state']['status']}",
             )
 
-    def should_be_automatically_captured(self, payment):
+    def should_be_captured(self, payment):
         # TODO: work out if payment needs to be delayed and and save result via API
         return True
 
@@ -115,7 +115,7 @@ class PaymentClient:
         If the status is 'success' or 'capturable' and the MTP payment doesn't have any email,
         it updates the email field on record and sends an email to the user.
 
-        If the status is 'capturable' and the payment should be automatically captured, this method
+        If the status is 'capturable' and the payment should be captured, this method
         captures and returns the new status.
 
         If a payment is captured or it's found in success state for the first time, an email
@@ -152,7 +152,7 @@ class PaymentClient:
                 self.update_payment(payment['uuid'], payment_attr_updates)
                 payment.update(payment_attr_updates)
 
-            if self.should_be_automatically_captured(payment):
+            if self.should_be_captured(payment):
                 # capture payment and send successful email
                 govuk_status = self.capture_govuk_payment(govuk_payment, context)
             elif 'email' in payment_attr_updates:

--- a/mtp_send_money/apps/send_money/tests/test_commands.py
+++ b/mtp_send_money/apps/send_money/tests/test_commands.py
@@ -361,7 +361,7 @@ class UpdateIncompletePaymentsTestCase(SimpleTestCase):
         })
 
     @override_settings(ENVIRONMENT='prod')  # because non-prod environments don't send to @outside.local
-    @mock.patch('send_money.payments.PaymentClient.should_be_automatically_captured', mock.Mock(return_value=True))
+    @mock.patch('send_money.payments.PaymentClient.should_be_captured', mock.Mock(return_value=True))
     def test_captured_payment_with_captured_date_gets_updated(self):
         payment_id = 'payment-id'
         govuk_payment_data = {
@@ -464,27 +464,27 @@ class UpdateIncompletePaymentsTestCase(SimpleTestCase):
 
         self.assertEqual(len(mail.outbox), 1)
 
-    @mock.patch('send_money.payments.PaymentClient.should_be_automatically_captured', mock.Mock(return_value=True))
+    @mock.patch('send_money.payments.PaymentClient.should_be_captured', mock.Mock(return_value=True))
     def test_captured_payment_doesnt_get_updated_with_missing_captured_date(self):
         self._test_captured_payment_doesnt_get_updated_before_capture({
             'capture_submit_time': '2016-10-27T15:11:05Z',
         })
 
-    @mock.patch('send_money.payments.PaymentClient.should_be_automatically_captured', mock.Mock(return_value=True))
+    @mock.patch('send_money.payments.PaymentClient.should_be_captured', mock.Mock(return_value=True))
     def test_captured_payment_doesnt_get_updated_with_null_capture_time(self):
         self._test_captured_payment_doesnt_get_updated_before_capture({
             'capture_submit_time': '2016-10-27T15:11:05Z',
             'captured_date': None
         })
 
-    @mock.patch('send_money.payments.PaymentClient.should_be_automatically_captured', mock.Mock(return_value=True))
+    @mock.patch('send_money.payments.PaymentClient.should_be_captured', mock.Mock(return_value=True))
     def test_captured_payment_doesnt_get_updated_with_blank_capture_time(self):
         self._test_captured_payment_doesnt_get_updated_before_capture({
             'capture_submit_time': '2016-10-27T15:11:05Z',
             'captured_date': ''
         })
 
-    @mock.patch('send_money.payments.PaymentClient.should_be_automatically_captured', mock.Mock(return_value=True))
+    @mock.patch('send_money.payments.PaymentClient.should_be_captured', mock.Mock(return_value=True))
     def test_captured_payment_doesnt_get_updated_with_invalid_capture_time(self):
         self._test_captured_payment_doesnt_get_updated_before_capture({
             'capture_submit_time': '2016-10-27T15:11:05Z',

--- a/mtp_send_money/apps/send_money/tests/test_payments.py
+++ b/mtp_send_money/apps/send_money/tests/test_payments.py
@@ -285,7 +285,7 @@ class CompletePaymentIfNecessaryTestCase(SimpleTestCase):
         }
 
         with \
-                mock.patch.object(client, 'should_be_automatically_captured', return_value=False), \
+                mock.patch.object(client, 'should_be_captured', return_value=False), \
                 responses.RequestsMock() as rsps:
 
             mock_auth(rsps)
@@ -360,7 +360,7 @@ class CompletePaymentIfNecessaryTestCase(SimpleTestCase):
             'amount': 1700,
         }
 
-        with mock.patch.object(client, 'should_be_automatically_captured', return_value=False):
+        with mock.patch.object(client, 'should_be_captured', return_value=False):
             status = client.complete_payment_if_necessary(payment, govuk_payment, context)
 
         self.assertEqual(status, PaymentStatus.capturable)
@@ -402,7 +402,7 @@ class CompletePaymentIfNecessaryTestCase(SimpleTestCase):
         }
 
         with \
-                mock.patch.object(client, 'should_be_automatically_captured', return_value=True), \
+                mock.patch.object(client, 'should_be_captured', return_value=True), \
                 responses.RequestsMock() as rsps:
 
             mock_auth(rsps)
@@ -445,7 +445,7 @@ class CompletePaymentIfNecessaryTestCase(SimpleTestCase):
         """
         Test that the method only sends any email if:
         - the govuk payment status is 'success' and the MTP payment didn't have the email field set
-        - the govuk payment status is 'capturable' and the payment should be automatically captured.
+        - the govuk payment status is 'capturable' and the MTP payment didn't have the email field set
         """
         client = PaymentClient()
 
@@ -461,7 +461,7 @@ class CompletePaymentIfNecessaryTestCase(SimpleTestCase):
         ]
 
         with \
-                mock.patch.object(client, 'should_be_automatically_captured', return_value=False), \
+                mock.patch.object(client, 'should_be_captured', return_value=False), \
                 silence_logger():
 
             for status in statuses:

--- a/mtp_send_money/apps/send_money/tests/test_views.py
+++ b/mtp_send_money/apps/send_money/tests/test_views.py
@@ -992,16 +992,16 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
                 response = self.client.get(
                     self.url, {'payment_ref': self.ref}, follow=False
                 )
-            self.assertContains(response, 'success')
-            self.assertResponseNotCacheable(response)
+        self.assertContains(response, 'success')
+        self.assertResponseNotCacheable(response)
 
-            # check session is cleared
-            for key in self.complete_session_keys:
-                self.assertNotIn(key, self.client.session)
+        # check session is cleared
+        for key in self.complete_session_keys:
+            self.assertNotIn(key, self.client.session)
 
-            self.assertEqual('Send money to someone in prison: your payment was successful', mail.outbox[0].subject)
-            self.assertTrue('WARGLE-B' in mail.outbox[0].body)
-            self.assertTrue('£17' in mail.outbox[0].body)
+        self.assertEqual('Send money to someone in prison: your payment was successful', mail.outbox[0].subject)
+        self.assertTrue('WARGLE-B' in mail.outbox[0].body)
+        self.assertTrue('£17' in mail.outbox[0].body)
 
     @override_settings(ENVIRONMENT='prod')  # because non-prod environments don't send to @outside.local
     @mock.patch('send_money.payments.PaymentClient.should_be_automatically_captured', mock.Mock(return_value=True))
@@ -1057,16 +1057,74 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
                     {'payment_ref': self.ref},
                     follow=False,
                 )
-            self.assertContains(response, 'success')
-            self.assertResponseNotCacheable(response)
+        self.assertContains(response, 'success')
+        self.assertResponseNotCacheable(response)
 
-            # check session is cleared
-            for key in self.complete_session_keys:
-                self.assertNotIn(key, self.client.session)
+        # check session is cleared
+        for key in self.complete_session_keys:
+            self.assertNotIn(key, self.client.session)
 
-            self.assertEqual('Send money to someone in prison: your payment was successful', mail.outbox[0].subject)
-            self.assertTrue('WARGLE-B' in mail.outbox[0].body)
-            self.assertTrue('£17' in mail.outbox[0].body)
+        self.assertEqual('Send money to someone in prison: your payment was successful', mail.outbox[0].subject)
+        self.assertTrue('WARGLE-B' in mail.outbox[0].body)
+        self.assertTrue('£17' in mail.outbox[0].body)
+
+    @override_settings(ENVIRONMENT='prod')  # because non-prod environments don't send to @outside.local
+    @mock.patch('send_money.payments.PaymentClient.should_be_automatically_captured', mock.Mock(return_value=False))
+    def test_puts_payment_on_hold(self):
+        """
+        Test that if the GOV.UK payment is in status 'capturable' and the payment should not be captured, the view:
+        - updates the MTP payment record with the email address and other details provided by GOV.UK Pay
+        - sends a email saying that the payment is on hold
+        - shows a page saying that the payment in on hold
+        """
+        self.choose_debit_card_payment_method()
+        self.fill_in_prisoner_details()
+        self.fill_in_amount()
+
+        with responses.RequestsMock() as rsps:
+            mock_auth(rsps)
+            rsps.add(
+                rsps.GET,
+                api_url(f'/payments/{self.ref}/'),
+                json=self.payment_data,
+                status=200,
+            )
+            rsps.add(
+                rsps.GET,
+                govuk_url(f'/payments/{self.processor_id}/'),
+                json={
+                    'payment_id': self.processor_id,
+                    'reference': 'wargle-blargle',
+                    'state': {'status': 'capturable'},
+                    'email': 'sender@outside.local',
+                    'settlement_summary': {
+                        'capture_submit_time': None,
+                        'captured_date': None,
+                    },
+                },
+                status=200,
+            )
+            rsps.add(
+                rsps.PATCH,
+                api_url('/payments/%s/' % 'wargle-blargle'),
+                status=200,
+            )
+            with self.patch_prisoner_details_check():
+                response = self.client.get(
+                    self.url,
+                    {'payment_ref': self.ref},
+                    follow=False,
+                )
+        self.assertContains(response, 'on hold')
+        self.assertResponseNotCacheable(response)
+
+        # check session is cleared
+        for key in self.complete_session_keys:
+            self.assertNotIn(key, self.client.session)
+
+        self.assertEqual('Send money to someone in prison: your payment has been put on hold', mail.outbox[0].subject)
+        self.assertTrue('WARGLE-B' in mail.outbox[0].body)
+        self.assertTrue('£17' in mail.outbox[0].body)
 
     def test_handles_api_update_errors(self):
         """

--- a/mtp_send_money/apps/send_money/tests/test_views.py
+++ b/mtp_send_money/apps/send_money/tests/test_views.py
@@ -19,7 +19,7 @@ from send_money.tests import (
     BaseTestCase, mock_auth,
     patch_notifications, patch_gov_uk_pay_availability_check, patch_govuk_pay_connection_check,
 )
-from send_money.views import should_be_captured_delayed
+from send_money.views import should_be_capture_delayed
 from send_money.utils import api_url, govuk_url, get_api_session
 
 
@@ -808,7 +808,7 @@ class DebitCardPaymentTestCase(DebitCardFlowTestCase):
                 fetch_redirect_response=False
             )
 
-    @mock.patch('send_money.views.should_be_captured_delayed', mock.Mock(return_value=True))
+    @mock.patch('send_money.views.should_be_capture_delayed', mock.Mock(return_value=True))
     def test_debit_card_payment_with_delayed_capture(self):
         """
         Test that if the payment should have delayed capture, the view calls the GOV.UK API
@@ -1527,9 +1527,9 @@ class PaymentServiceUnavailableTestCase(DebitCardFlowTestCase):
             self.assertContains(response, 'success')
 
 
-class ShouldBeCapturedDelayed(SimpleTestCase):
+class ShouldBeCaptureDelayed(SimpleTestCase):
     """
-    Tests related to the should_be_captured_delayed function.
+    Tests related to the should_be_capture_delayed function.
 
     Note: the tests try a few times to exclude any randomness.
     """
@@ -1542,7 +1542,7 @@ class ShouldBeCapturedDelayed(SimpleTestCase):
         """
         for _ in range(10):
             self.assertEqual(
-                should_be_captured_delayed(),
+                should_be_capture_delayed(),
                 False,
             )
 
@@ -1554,7 +1554,7 @@ class ShouldBeCapturedDelayed(SimpleTestCase):
         """
         for _ in range(10):
             self.assertEqual(
-                should_be_captured_delayed(),
+                should_be_capture_delayed(),
                 True,
             )
 
@@ -1566,7 +1566,7 @@ class ShouldBeCapturedDelayed(SimpleTestCase):
         """
         with self.assertLogs('mtp', level='ERROR') as cm:
             self.assertEqual(
-                should_be_captured_delayed(),
+                should_be_capture_delayed(),
                 False,
             )
 
@@ -1586,7 +1586,7 @@ class ShouldBeCapturedDelayed(SimpleTestCase):
         """
         with self.assertLogs('mtp', level='ERROR') as cm:
             self.assertEqual(
-                should_be_captured_delayed(),
+                should_be_capture_delayed(),
                 False,
             )
 
@@ -1606,7 +1606,7 @@ class ShouldBeCapturedDelayed(SimpleTestCase):
         """
         with self.assertLogs('mtp', level='ERROR') as cm:
             self.assertEqual(
-                should_be_captured_delayed(),
+                should_be_capture_delayed(),
                 False,
             )
 
@@ -1629,7 +1629,7 @@ class ShouldBeCapturedDelayed(SimpleTestCase):
             False: 0,
         }
         for _ in range(100):
-            chance[should_be_captured_delayed()] += 1
+            chance[should_be_capture_delayed()] += 1
 
         # we can't accurately check the figures
         self.assertTrue(chance[True] > 0)

--- a/mtp_send_money/apps/send_money/tests/test_views.py
+++ b/mtp_send_money/apps/send_money/tests/test_views.py
@@ -1004,7 +1004,7 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
         self.assertTrue('£17' in mail.outbox[0].body)
 
     @override_settings(ENVIRONMENT='prod')  # because non-prod environments don't send to @outside.local
-    @mock.patch('send_money.payments.PaymentClient.should_be_automatically_captured', mock.Mock(return_value=True))
+    @mock.patch('send_money.payments.PaymentClient.should_be_captured', mock.Mock(return_value=True))
     def test_automatically_captures_payment(self):
         """
         Test that if the GOV.UK payment is in status 'capturable' and the payment should be
@@ -1069,7 +1069,7 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
         self.assertTrue('£17' in mail.outbox[0].body)
 
     @override_settings(ENVIRONMENT='prod')  # because non-prod environments don't send to @outside.local
-    @mock.patch('send_money.payments.PaymentClient.should_be_automatically_captured', mock.Mock(return_value=False))
+    @mock.patch('send_money.payments.PaymentClient.should_be_captured', mock.Mock(return_value=False))
     def test_puts_payment_on_hold(self):
         """
         Test that if the GOV.UK payment is in status 'capturable' and the payment should not be captured, the view:

--- a/mtp_send_money/apps/send_money/utils.py
+++ b/mtp_send_money/apps/send_money/utils.py
@@ -6,15 +6,13 @@ import re
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
-from django.urls import reverse
 from django.utils import formats
 from django.utils.cache import patch_cache_control
 from django.utils.dateformat import format as format_date
 from django.utils.dateparse import parse_date
 from django.utils.encoding import force_text
-from django.utils.translation import gettext, gettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from mtp_common.auth import api_client, urljoin
-from mtp_common.tasks import send_email
 import requests
 from requests.exceptions import RequestException, Timeout
 
@@ -52,20 +50,6 @@ def can_load_govuk_pay_image():
     except RequestException:
         logger.exception('Failed to load GOV.UK Pay image')
         return False
-
-
-def send_notification(email, context):
-    context.update({
-        'site_url': settings.START_PAGE_URL,
-        'feedback_url': site_url(reverse('submit_ticket')),
-        'help_url': site_url(reverse('send_money:help')),
-    })
-    send_email(
-        email, 'send_money/email/debit-card-confirmation.txt',
-        gettext('Send money to someone in prison: your payment was successful'),
-        context=context, html_template='send_money/email/debit-card-confirmation.html',
-        anymail_tags=['dc-received'],
-    )
 
 
 def validate_prisoner_number(value):

--- a/mtp_send_money/apps/send_money/views.py
+++ b/mtp_send_money/apps/send_money/views.py
@@ -44,7 +44,7 @@ def clear_session_view(request):
     return redirect(build_view_url(request, PaymentMethodChoiceView.url_name))
 
 
-def should_be_captured_delayed():
+def should_be_capture_delayed():
     """
     Util function to roll out delayed payment capture gradually in order to limit damage caused by unknown problems.
     Returns True if the payment should be created with delayed_capture == True with a chance in
@@ -397,7 +397,7 @@ class DebitCardPaymentView(DebitCardFlow):
             failure_context['short_payment_ref'] = payment_ref[:8]
 
             new_govuk_payment = {
-                'delayed_capture': should_be_captured_delayed(),
+                'delayed_capture': should_be_capture_delayed(),
                 'amount': amount_pence + service_charge_pence,
                 'reference': payment_ref,
                 'description': gettext('To this prisoner: %(prisoner_number)s' % prisoner_details),

--- a/mtp_send_money/templates/send_money/email/bank-transfer-reference.html
+++ b/mtp_send_money/templates/send_money/email/bank-transfer-reference.html
@@ -18,7 +18,7 @@
 
     <li>
       <p>{% trans 'Copy and paste these details into the transfer:' %}</p>
-      <table>
+      <table style="font-family: sans-serif; border-left: 10px solid #b1b4b6; padding-left: 15px;">
         <tbody>
           <tr>
             <th style="font-weight:normal;text-align:left">{% trans 'Account number:' %}</th>

--- a/mtp_send_money/templates/send_money/email/debit-card-confirmation.html
+++ b/mtp_send_money/templates/send_money/email/debit-card-confirmation.html
@@ -17,13 +17,13 @@
     {% trans 'You’ll get a further email when the prisoner’s account has been credited to confirm your money has arrived.' %}
   </p>
 
-  <table cellspacing="10" style="font-family: sans-serif;">
+  <table cellspacing="10" style="font-family: sans-serif; border-left: 10px solid #b1b4b6; padding-left: 15px;">
     <tr>
       <th valign="top" align="left">{% trans 'Payment to:' %}</th>
       <td>{{ prisoner_name }}</td>
     </tr>
     <tr>
-      <th valign="top" align="left">{% trans 'Amount paid:' %}</th>
+      <th valign="top" align="left">{% trans 'Amount:' %}</th>
       <td>{{ amount|currency_format }}</td>
     </tr>
     <tr>

--- a/mtp_send_money/templates/send_money/email/debit-card-confirmation.txt
+++ b/mtp_send_money/templates/send_money/email/debit-card-confirmation.txt
@@ -10,7 +10,7 @@ GOV.UK - {% trans 'Send money to someone in prison' %}
 {% trans 'You’ll get a further email when the prisoner’s account has been credited to confirm your money has arrived.' %}
 
 {% trans 'Payment to' %}: {{ prisoner_name }}
-{% trans 'Amount paid' %}: {{ amount|currency_format }}
+{% trans 'Amount' %}: {{ amount|currency_format }}
 {% trans 'Date payment made' %}: {% now 'd/m/Y' %}
 
 

--- a/mtp_send_money/templates/send_money/email/debit-card-on-hold.html
+++ b/mtp_send_money/templates/send_money/email/debit-card-on-hold.html
@@ -1,0 +1,52 @@
+{% extends 'mtp_common/email_base.html' %}
+{% load i18n %}
+{% load send_money %}
+
+{% block inner_content %}
+  <p>{% trans 'Dear sender,' %}</p>
+
+  <p>
+    <strong>{% trans 'This payment has been put on hold for up to 5 days.' %}</strong>
+  </p>
+
+  <table cellspacing="10" style="font-family: sans-serif; border-left: 10px solid #b1b4b6; padding-left: 15px;">
+    <tr>
+      <th valign="top" align="left">{% trans 'Payment to:' %}</th>
+      <td>{{ prisoner_name }}</td>
+    </tr>
+    <tr>
+      <th valign="top" align="left">{% trans 'Amount:' %}</th>
+      <td>{{ amount|currency_format }}</td>
+    </tr>
+    <tr>
+      <th valign="top" align="left">{% trans 'Date:' %}</th>
+      <td>{% now 'd/m/Y' %}</td>
+    </tr>
+    <tr>
+      <th valign="top" align="left">{% trans 'Reference:' %}</th>
+      <td>{{ short_payment_ref }}</td>
+    </tr>
+  </table>
+
+  <p>
+    {% trans 'To maintain a high level of prison safety we do regular security checks.' %}
+  </p>
+  <p>
+    {% trans 'We’ll email you a payment update as soon as we can and are sorry for any inconvenience this may cause.' %}
+  </p>
+
+  <p>
+    {% trans 'Kind regards,' %}
+  </p>
+  <p>
+    {% trans 'Prisoner Money team' %}<br />
+  </p>
+
+  <p>
+    {% blocktrans trimmed %}
+      <a href="{{ help_url }}">Help</a> with problems using this service or how to <a href="{{ feedback_url }}">contact us</a>.
+    {% endblocktrans %}
+  </p>
+
+  <p><a href="{{ site_url }}">{% trans 'Back to the service' %}</a></p>
+{% endblock %}

--- a/mtp_send_money/templates/send_money/email/debit-card-on-hold.txt
+++ b/mtp_send_money/templates/send_money/email/debit-card-on-hold.txt
@@ -1,0 +1,23 @@
+{% load i18n %}
+{% load send_money %}
+GOV.UK - {% trans 'Send money to someone in prison' %}
+
+{% trans 'Dear sender,' %}
+
+{% trans 'This payment has been put on hold for up to 5 days.' %}
+
+{% trans 'Payment to' %}: {{ prisoner_name }}
+{% trans 'Amount' %}: {{ amount|currency_format }}
+{% trans 'Date' %}: {% now 'd/m/Y' %}
+{% trans 'Reference' %}: {{ short_payment_ref }}
+
+{% trans 'To maintain a high level of prison safety we do regular security checks.' %}
+{% trans 'We’ll email you a payment update as soon as we can and are sorry for any inconvenience this may cause.' %}
+
+{% trans 'Kind regards,' %}
+{% trans 'Prisoner Money team' %}
+
+{% trans 'Help with problems using this service:' %} {{ help_url }}
+{% trans 'Leave feedback or contact us at:' %} {{ feedback_url }}
+
+{% trans 'Back to the service:' %} {{ site_url }}


### PR DESCRIPTION
This:
- sends an email to the sender when a payment is put on hold
- moves all logic sending emails to the `mail.py` module
- renames some functions
- changes the design of existing emails slightly to add left grey border

Note: Different letter closings, should we make everything consistent?


### payment on hold
![Screenshot 2019-12-02 at 16 02 00](https://user-images.githubusercontent.com/178865/70049054-b94f2800-15c3-11ea-8917-a64e7fd14f3c.png)

### payment successful
![Screenshot 2019-12-02 at 16 02 30](https://user-images.githubusercontent.com/178865/70049081-c9ff9e00-15c3-11ea-8992-a9b0331a8069.png)

### bank transfer reference
![Screenshot 2019-12-02 at 16 01 30](https://user-images.githubusercontent.com/178865/70049109-d71c8d00-15c3-11ea-9138-bdcefeed0c65.png)
