### PR TITLE
Cancel a payment

### DIFF
--- a/mtp_send_money/apps/send_money/mail.py
+++ b/mtp_send_money/apps/send_money/mail.py
@@ -42,6 +42,16 @@ def send_email_for_card_payment_on_hold(email, context):
     )
 
 
+def send_email_for_card_payment_cancelled(email, context):
+    _send_notification_email(
+        email,
+        'debit-card-cancelled',
+        gettext('your payment has NOT been sent to the prisoner'),
+        ['dc-cancelled'],
+        context,
+    )
+
+
 def send_email_for_bank_transfer_reference(email, context):
     _send_notification_email(
         email,

--- a/mtp_send_money/apps/send_money/payments.py
+++ b/mtp_send_money/apps/send_money/payments.py
@@ -45,6 +45,15 @@ class PaymentStatus(enum.Enum):
         return self in [self.created, self.started, self.submitted]
 
 
+class CheckResult(enum.Enum):
+    """
+    Maps the next action to perform based on the security check data.
+    """
+    delay = 'Delay'
+    capture = 'Capture'
+    cancel = 'Cancel'
+
+
 def is_active_payment(payment):
     if payment['status'] == 'pending':
         return True
@@ -104,9 +113,12 @@ class PaymentClient:
                 f"Unknown status: {govuk_payment['state']['status']}",
             )
 
-    def should_be_captured(self, payment):
-        # TODO: work out if payment needs to be delayed and and save result via API
-        return True
+    def get_security_check_result(self, payment):
+        """
+        Checks the security check for 'payment' and returns a CheckResult indicating the next
+        action to perform.
+        """
+        return CheckResult.capture
 
     def complete_payment_if_necessary(self, payment, govuk_payment, context):
         """
@@ -152,12 +164,20 @@ class PaymentClient:
                 self.update_payment(payment['uuid'], payment_attr_updates)
                 payment.update(payment_attr_updates)
 
-            if self.should_be_captured(payment):
+            # decide next action
+            check_action = self.get_security_check_result(payment)
+            if check_action == CheckResult.delay:
+                # if the user hasn't been notified, send email
+                if 'email' in payment_attr_updates:
+                    email = payment_attr_updates['email']
+                    send_email_for_card_payment_on_hold(email, context)
+            elif check_action == CheckResult.capture:
                 # capture payment and send successful email
+                # TODO: check on payment if check was actioned by and send a different
+                #   confirmation email if so
                 govuk_status = self.capture_govuk_payment(govuk_payment, context)
-            elif 'email' in payment_attr_updates:
-                email = payment_attr_updates['email']
-                send_email_for_card_payment_on_hold(email, context)
+            elif check_action == CheckResult.cancel:
+                pass
         elif govuk_status == PaymentStatus.success:
             # TODO consider updating other attrs using `get_completion_payment_attr_updates`
             email = govuk_payment.get('email')

--- a/mtp_send_money/apps/send_money/tests/test_commands.py
+++ b/mtp_send_money/apps/send_money/tests/test_commands.py
@@ -9,6 +9,7 @@ from django.test.testcases import SimpleTestCase
 from django.utils.timezone import utc
 import responses
 
+from send_money.payments import CheckResult
 from send_money.tests import mock_auth
 from send_money.utils import api_url, govuk_url
 
@@ -361,7 +362,10 @@ class UpdateIncompletePaymentsTestCase(SimpleTestCase):
         })
 
     @override_settings(ENVIRONMENT='prod')  # because non-prod environments don't send to @outside.local
-    @mock.patch('send_money.payments.PaymentClient.should_be_captured', mock.Mock(return_value=True))
+    @mock.patch(
+        'send_money.payments.PaymentClient.get_security_check_result',
+        mock.Mock(return_value=CheckResult.capture),
+    )
     def test_captured_payment_with_captured_date_gets_updated(self):
         payment_id = 'payment-id'
         govuk_payment_data = {
@@ -464,27 +468,39 @@ class UpdateIncompletePaymentsTestCase(SimpleTestCase):
 
         self.assertEqual(len(mail.outbox), 1)
 
-    @mock.patch('send_money.payments.PaymentClient.should_be_captured', mock.Mock(return_value=True))
+    @mock.patch(
+        'send_money.payments.PaymentClient.get_security_check_result',
+        mock.Mock(return_value=CheckResult.capture),
+    )
     def test_captured_payment_doesnt_get_updated_with_missing_captured_date(self):
         self._test_captured_payment_doesnt_get_updated_before_capture({
             'capture_submit_time': '2016-10-27T15:11:05Z',
         })
 
-    @mock.patch('send_money.payments.PaymentClient.should_be_captured', mock.Mock(return_value=True))
+    @mock.patch(
+        'send_money.payments.PaymentClient.get_security_check_result',
+        mock.Mock(return_value=CheckResult.capture),
+    )
     def test_captured_payment_doesnt_get_updated_with_null_capture_time(self):
         self._test_captured_payment_doesnt_get_updated_before_capture({
             'capture_submit_time': '2016-10-27T15:11:05Z',
             'captured_date': None
         })
 
-    @mock.patch('send_money.payments.PaymentClient.should_be_captured', mock.Mock(return_value=True))
+    @mock.patch(
+        'send_money.payments.PaymentClient.get_security_check_result',
+        mock.Mock(return_value=CheckResult.capture),
+    )
     def test_captured_payment_doesnt_get_updated_with_blank_capture_time(self):
         self._test_captured_payment_doesnt_get_updated_before_capture({
             'capture_submit_time': '2016-10-27T15:11:05Z',
             'captured_date': ''
         })
 
-    @mock.patch('send_money.payments.PaymentClient.should_be_captured', mock.Mock(return_value=True))
+    @mock.patch(
+        'send_money.payments.PaymentClient.get_security_check_result',
+        mock.Mock(return_value=CheckResult.capture),
+    )
     def test_captured_payment_doesnt_get_updated_with_invalid_capture_time(self):
         self._test_captured_payment_doesnt_get_updated_before_capture({
             'capture_submit_time': '2016-10-27T15:11:05Z',

--- a/mtp_send_money/templates/send_money/email/debit-card-cancelled.html
+++ b/mtp_send_money/templates/send_money/email/debit-card-cancelled.html
@@ -1,0 +1,64 @@
+{% extends 'mtp_common/email_base.html' %}
+{% load i18n %}
+{% load send_money %}
+
+{% block inner_content %}
+  <p>{% trans 'Dear sender,' %}</p>
+
+  <p>
+    <strong>{% trans 'This payment has NOT been sent to the prisoner.' %}</strong>
+  </p>
+
+  <table cellspacing="10" style="font-family: sans-serif; border-left: 10px solid #b1b4b6; padding-left: 15px;">
+    <tr>
+      <th valign="top" align="left">{% trans 'Payment to:' %}</th>
+      <td>{{ prisoner_name }}</td>
+    </tr>
+    <tr>
+      <th valign="top" align="left">{% trans 'Amount:' %}</th>
+      <td>{{ amount|currency_format }}</td>
+    </tr>
+    <tr>
+      <th valign="top" align="left">{% trans 'Reference:' %}</th>
+      <td>{{ short_payment_ref }}</td>
+    </tr>
+  </table>
+
+  <p>
+    {% trans 'We’re emailing to let you know that this payment has not gone through this time.' %}
+  </p>
+
+  <p>
+    {% trans 'To maintain a high level of prison safety we do regular security checks.' %} <br />
+    {% trans 'Sometimes this means payments can’t be allowed to go through to the prisoner.' %}
+  </p>
+
+  <p>
+    <strong>{% trans 'What now?' %}</strong>
+  </p>
+
+  <p>
+    {% blocktrans trimmed %}
+      Your debit card payment has <strong>not</strong> been taken from your account.
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    {% blocktrans trimmed %}
+    If you need further assistance with this, please <a href="{{ feedback_url }}">contact us</a>.
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    {% trans 'We’re sorry for any inconvenience this may have caused.' %}
+  </p>
+
+  <p>
+    {% trans 'Kind regards,' %}
+  </p>
+  <p>
+    {% trans 'Prisoner Money team' %}<br />
+  </p>
+
+  <p><a href="{{ site_url }}">{% trans 'Back to the service' %}</a></p>
+{% endblock %}

--- a/mtp_send_money/templates/send_money/email/debit-card-cancelled.txt
+++ b/mtp_send_money/templates/send_money/email/debit-card-cancelled.txt
@@ -1,0 +1,28 @@
+{% load i18n %}
+{% load send_money %}
+GOV.UK - {% trans 'Send money to someone in prison' %}
+
+{% trans 'Dear sender,' %}
+
+{% trans 'This payment has NOT been sent to the prisoner.' %}
+
+{% trans 'Payment to' %}: {{ prisoner_name }}
+{% trans 'Amount' %}: {{ amount|currency_format }}
+{% trans 'Reference' %}: {{ short_payment_ref }}
+
+{% trans 'We’re emailing to let you know that this payment has not gone through this time.' %}
+
+{% trans 'To maintain a high level of prison safety we do regular security checks.' %}
+{% trans 'Sometimes this means payments can’t be allowed to go through to the prisoner.' %}
+
+{% trans 'What now?' %}
+{% trans 'Your debit card payment has not been taken from your account.' %}
+
+{% trans 'If you need further assistance with this, please contact us at:' %} {{ feedback_url }}
+
+{% trans 'We’re sorry for any inconvenience this may have caused.' %}
+
+{% trans 'Kind regards,' %}
+{% trans 'Prisoner Money team' %}
+
+{% trans 'Back to the service:' %} {{ site_url }}


### PR DESCRIPTION
This adds the logic of cancelling a payment in capturable status if required.

The logic behind determining what to do with a capturable payment is encapsulated in the `get_security_check_result` method and will change in future PRs where we will examine the security check data on the payment object.

Unhappy cases are not addressed here yet (e.g. if GOV.UK Pay encounters a problem with Worldpay when capturing or cancelling a payment).