### PR TITLE
Send confirmation email only when capture date available

### DIFF
--- a/mtp_send_money/apps/send_money/management/commands/update_incomplete_payments.py
+++ b/mtp_send_money/apps/send_money/management/commands/update_incomplete_payments.py
@@ -49,6 +49,7 @@ class Command(BaseCommand):
             context = {
                 'short_payment_ref': payment_ref[:8].upper(),
                 'prisoner_name': payment['recipient_name'],
+                'prisoner_number': payment['prisoner_number'],
                 'amount': Decimal(payment['amount']) / 100,
             }
 
@@ -56,7 +57,7 @@ class Command(BaseCommand):
                 govuk_payment = payment_client.get_govuk_payment(govuk_id)
                 was_capturable = payment_client.parse_govuk_payment_status(govuk_payment) == PaymentStatus.capturable
                 govuk_status = payment_client.complete_payment_if_necessary(
-                    payment, govuk_payment, context
+                    payment, govuk_payment, context,
                 )
 
                 # not yet finished and can't do anything so skip
@@ -72,7 +73,7 @@ class Command(BaseCommand):
                 success = govuk_status == PaymentStatus.success
 
                 payment_client.update_completed_payment(
-                    payment_ref, govuk_payment, success
+                    payment_ref, govuk_payment, success, context,
                 )
             except OAuth2Error:
                 logger.exception(

--- a/mtp_send_money/apps/send_money/tests/test_views.py
+++ b/mtp_send_money/apps/send_money/tests/test_views.py
@@ -955,8 +955,8 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
         """
         Test that if the GOV.UK payment is in status 'success', the view:
         - updates the MTP payment record with the email address provided by GOV.UK Pay
-        - sends a confirmation email
         - shows a confirmation page
+        - no email is sent (the confirmation email is sent when we get the capture date)
         """
         self.choose_debit_card_payment_method()
         self.fill_in_prisoner_details()
@@ -1000,9 +1000,7 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
         for key in self.complete_session_keys:
             self.assertNotIn(key, self.client.session)
 
-        self.assertEqual('Send money to someone in prison: your payment was successful', mail.outbox[0].subject)
-        self.assertTrue('WARGLE-B' in mail.outbox[0].body)
-        self.assertTrue('£17' in mail.outbox[0].body)
+        self.assertEqual(len(mail.outbox), 0)
 
     @override_settings(ENVIRONMENT='prod')  # because non-prod environments don't send to @outside.local
     @mock.patch(
@@ -1015,8 +1013,8 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
         automatically captured, the view:
         - updates the MTP payment record with the email address and other details provided by GOV.UK Pay
         - captures the payment
-        - sends a confirmation email
         - shows a confirmation page
+        - no email is sent (the confirmation email is sent when we get the capture date)
         """
         self.choose_debit_card_payment_method()
         self.fill_in_prisoner_details()
@@ -1068,9 +1066,7 @@ class DebitCardConfirmationTestCase(DebitCardFlowTestCase):
         for key in self.complete_session_keys:
             self.assertNotIn(key, self.client.session)
 
-        self.assertEqual('Send money to someone in prison: your payment was successful', mail.outbox[0].subject)
-        self.assertTrue('WARGLE-B' in mail.outbox[0].body)
-        self.assertTrue('£17' in mail.outbox[0].body)
+        self.assertEqual(len(mail.outbox), 0)
 
     @override_settings(ENVIRONMENT='prod')  # because non-prod environments don't send to @outside.local
     @mock.patch(


### PR DESCRIPTION
Before this, we were sending a confirmation email when capturing the payment (implicitly with non-delayed payment or explicitly when calling the GOV.UK `/capture` on delayed payments).

However the GOV.UK operation is async and Pay captures the payment at a later time, even after days. It's quite unlikely but Pay could encounter difficulties when capturing the payment and in these cases the payment status would change from `success` to `failed`.

For this reason, it's safer to send the confirmation email when the capture date is available so that we know for sure that the payment was actually captured.