### PR TITLE
Send cancellation email when really cancelled

### DIFF
--- a/mtp_send_money/apps/send_money/mail.py
+++ b/mtp_send_money/apps/send_money/mail.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import gettext
@@ -22,7 +24,18 @@ def _send_notification_email(email, template_name, subject, tags, context):
     )
 
 
-def send_email_for_card_payment_confirmation(email, context):
+def _get_email_context_for_payment(payment):
+    return {
+        'short_payment_ref': payment['uuid'][:8].upper(),
+        'prisoner_name': payment['recipient_name'],
+        'prisoner_number': payment['prisoner_number'],
+        'amount': Decimal(payment['amount']) / 100,
+    }
+
+
+def send_email_for_card_payment_confirmation(email, payment):
+    context = _get_email_context_for_payment(payment)
+
     _send_notification_email(
         email,
         'debit-card-confirmation',
@@ -32,7 +45,9 @@ def send_email_for_card_payment_confirmation(email, context):
     )
 
 
-def send_email_for_card_payment_on_hold(email, context):
+def send_email_for_card_payment_on_hold(email, payment):
+    context = _get_email_context_for_payment(payment)
+
     _send_notification_email(
         email,
         'debit-card-on-hold',
@@ -42,7 +57,9 @@ def send_email_for_card_payment_on_hold(email, context):
     )
 
 
-def send_email_for_card_payment_cancelled(email, context):
+def send_email_for_card_payment_cancelled(email, payment):
+    context = _get_email_context_for_payment(payment)
+
     _send_notification_email(
         email,
         'debit-card-cancelled',

--- a/mtp_send_money/apps/send_money/management/commands/update_incomplete_payments.py
+++ b/mtp_send_money/apps/send_money/management/commands/update_incomplete_payments.py
@@ -9,7 +9,7 @@ from oauthlib.oauth2 import OAuth2Error
 from requests.exceptions import RequestException
 
 from send_money.exceptions import GovUkPaymentStatusException
-from send_money.payments import PaymentClient, PaymentStatus
+from send_money.payments import PaymentClient
 
 logger = logging.getLogger('mtp')
 
@@ -48,22 +48,20 @@ class Command(BaseCommand):
 
             try:
                 govuk_payment = payment_client.get_govuk_payment(govuk_id)
-                was_capturable = payment_client.parse_govuk_payment_status(govuk_payment) == PaymentStatus.capturable
+                previous_govuk_status = payment_client.parse_govuk_payment_status(govuk_payment)
                 govuk_status = payment_client.complete_payment_if_necessary(payment, govuk_payment)
 
                 # not yet finished and can't do anything so skip
                 if govuk_status and not govuk_status.finished():
                     continue
 
-                if was_capturable and govuk_status == PaymentStatus.success:
-                    # refresh govuk payment to get the captured time
+                if previous_govuk_status != govuk_status:
+                    # refresh govuk payment to get up-to-date fields (e.g. error codes)
                     govuk_payment = payment_client.get_govuk_payment(govuk_id)
 
                 # if here, status is either success, failed, cancelled, error
                 # or None (in case of govuk payment not found)
-                success = govuk_status == PaymentStatus.success
-
-                payment_client.update_completed_payment(payment, govuk_payment, success)
+                payment_client.update_completed_payment(payment, govuk_payment)
             except OAuth2Error:
                 logger.exception(
                     'Scheduled job: Authentication error while processing %s' % payment_ref

--- a/mtp_send_money/apps/send_money/views.py
+++ b/mtp_send_money/apps/send_money/views.py
@@ -395,10 +395,7 @@ class DebitCardConfirmationView(TemplateView):
                 govuk_id = payment['processor_id']
                 govuk_payment = payment_client.get_govuk_payment(govuk_id)
 
-                # check payment and send confirmation email if successful
-                self.status = payment_client.complete_payment_if_necessary(
-                    payment, govuk_payment, kwargs
-                )
+                self.status = payment_client.complete_payment_if_necessary(payment, govuk_payment)
 
                 # if status is error, failed or cancelled, redirect back to the start
                 # as GOV.UK Pay has already shown an error page.


### PR DESCRIPTION
To make things consistent this moves the logic of sending a cancellation email to the `update_completed_payment` method where we update the mtp payment status.

There was also a bit of refactoring on how the context for the email is constructed and how `update_completed_payment` works out the if a payment was successful.