### PR TITLE
Delayed payments timing out

### DIFF
--- a/mtp_send_money/apps/send_money/mail.py
+++ b/mtp_send_money/apps/send_money/mail.py
@@ -69,11 +69,23 @@ def send_email_for_card_payment_cancelled(email, payment):
     )
 
 
+def send_email_for_card_payment_timed_out(email, payment):
+    context = _get_email_context_for_payment(payment)
+
+    _send_notification_email(
+        email,
+        'debit-card-timeout',
+        gettext('payment session expired'),
+        ['dc-timeout'],
+        context,
+    )
+
+
 def send_email_for_bank_transfer_reference(email, context):
     _send_notification_email(
         email,
         'bank-transfer-reference',
-        gettext('Your prisoner reference is %(bank_transfer_reference)s' % context),
+        gettext('your prisoner reference is %(bank_transfer_reference)s' % context),
         ['bt-reference'],
         context,
     )

--- a/mtp_send_money/apps/send_money/management/commands/update_incomplete_payments.py
+++ b/mtp_send_money/apps/send_money/management/commands/update_incomplete_payments.py
@@ -9,7 +9,7 @@ from oauthlib.oauth2 import OAuth2Error
 from requests.exceptions import RequestException
 
 from send_money.exceptions import GovUkPaymentStatusException
-from send_money.payments import PaymentClient, PaymentStatus
+from send_money.payments import GovUkPaymentStatus, PaymentClient
 
 logger = logging.getLogger('mtp')
 
@@ -48,7 +48,7 @@ class Command(BaseCommand):
 
             try:
                 govuk_payment = payment_client.get_govuk_payment(govuk_id)
-                previous_govuk_status = PaymentStatus.get_from_govuk_payment(govuk_payment)
+                previous_govuk_status = GovUkPaymentStatus.get_from_govuk_payment(govuk_payment)
                 govuk_status = payment_client.complete_payment_if_necessary(payment, govuk_payment)
 
                 # not yet finished and can't do anything so skip

--- a/mtp_send_money/apps/send_money/management/commands/update_incomplete_payments.py
+++ b/mtp_send_money/apps/send_money/management/commands/update_incomplete_payments.py
@@ -9,7 +9,7 @@ from oauthlib.oauth2 import OAuth2Error
 from requests.exceptions import RequestException
 
 from send_money.exceptions import GovUkPaymentStatusException
-from send_money.payments import PaymentClient
+from send_money.payments import PaymentClient, PaymentStatus
 
 logger = logging.getLogger('mtp')
 
@@ -48,7 +48,7 @@ class Command(BaseCommand):
 
             try:
                 govuk_payment = payment_client.get_govuk_payment(govuk_id)
-                previous_govuk_status = payment_client.parse_govuk_payment_status(govuk_payment)
+                previous_govuk_status = PaymentStatus.get_from_govuk_payment(govuk_payment)
                 govuk_status = payment_client.complete_payment_if_necessary(payment, govuk_payment)
 
                 # not yet finished and can't do anything so skip

--- a/mtp_send_money/apps/send_money/payments.py
+++ b/mtp_send_money/apps/send_money/payments.py
@@ -338,6 +338,28 @@ class PaymentClient:
         except (ValueError, KeyError):
             raise RequestException('Cannot parse response', response=response)
 
+    def get_govuk_payment_events(self, govuk_id):
+        """
+        :return: list with events information about a certain govuk payment.
+
+        :param govuk_id: id of the govuk payment
+        :raise HTTPError: if GOV.UK Pay returns a 4xx or 5xx response
+        :raise RequestException: if the response body cannot be parsed
+        """
+        response = requests.get(
+            govuk_url(f'/payments/{govuk_id}/events'),
+            headers=govuk_headers(),
+            timeout=15,
+        )
+
+        response.raise_for_status()
+
+        try:
+            data = response.json()
+            return data['events']
+        except (ValueError, KeyError):
+            raise RequestException('Cannot parse response', response=response)
+
     def get_govuk_capture_time(self, govuk_payment):
         try:
             capture_submit_time = parse_datetime(

--- a/mtp_send_money/templates/send_money/email/debit-card-timeout.html
+++ b/mtp_send_money/templates/send_money/email/debit-card-timeout.html
@@ -1,0 +1,60 @@
+{% extends 'mtp_common/email_base.html' %}
+{% load i18n %}
+{% load send_money %}
+
+{% block inner_content %}
+  <p>{% trans 'Dear sender,' %}</p>
+
+  <p>
+    {% blocktrans trimmed %}
+      We’re sorry to tell you that the <strong>payment session expired</strong> before your payment could be taken.
+    {% endblocktrans %}
+  </p>
+  <p>
+    {% blocktrans trimmed %}
+      This payment has <strong>not</strong> gone through to the prisoner’s account.
+    {% endblocktrans %}
+  </p>
+
+  <table cellspacing="10" style="font-family: sans-serif; border-left: 10px solid #b1b4b6; padding-left: 15px;">
+    <tr>
+      <th valign="top" align="left">{% trans 'Payment to:' %}</th>
+      <td>{{ prisoner_name }}</td>
+    </tr>
+    <tr>
+      <th valign="top" align="left">{% trans 'Amount:' %}</th>
+      <td>{{ amount|currency_format }}</td>
+    </tr>
+    <tr>
+      <th valign="top" align="left">{% trans 'Reference:' %}</th>
+      <td>{{ short_payment_ref }}</td>
+    </tr>
+  </table>
+
+  <p>
+    <strong>{% trans 'What now?' %}</strong>
+  </p>
+
+  <p>
+    {% blocktrans trimmed %}
+      Please go to <a href="{{ site_url }}">Send money to someone in prison</a> and try again.
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    {% trans 'We’re sorry for any inconvenience this may have caused but we’re keen to keep the service running smoothly.' %}
+  </p>
+
+  <p>
+    {% blocktrans trimmed %}
+      <a href="{{ feedback_url }}">Contact us</a> if this is a recurring problem for you or if you need further more help.
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    {% trans 'Kind regards,' %}
+  </p>
+  <p>
+    {% trans 'Prisoner money team' %}<br />
+  </p>
+{% endblock %}

--- a/mtp_send_money/templates/send_money/email/debit-card-timeout.txt
+++ b/mtp_send_money/templates/send_money/email/debit-card-timeout.txt
@@ -1,0 +1,24 @@
+{% load i18n %}
+{% load send_money %}
+GOV.UK - {% trans 'Send money to someone in prison' %}
+
+{% trans 'Dear sender,' %}
+
+{% trans 'We’re sorry to tell you that the payment session expired before your payment could be taken.' %}
+
+{% trans 'This payment has not gone through to the prisoner’s account.' %}
+
+{% trans 'Payment to' %}: {{ prisoner_name }}
+{% trans 'Amount' %}: {{ amount|currency_format }}
+{% trans 'Reference' %}: {{ short_payment_ref }}
+
+{% trans 'What now?' %}
+
+{% trans 'Please go to Send money to someone in prison and try again:' %} {{ site_url }}
+
+{% trans 'We’re sorry for any inconvenience this may have caused but we’re keen to keep the service running smoothly.' %}
+
+{% trans 'Contact us if this is a recurring problem for you or if you need further more help:' %} {{ feedback_url }}
+
+{% trans 'Kind regards,' %}
+{% trans 'Prisoner money team' %}


### PR DESCRIPTION
When a capturable govuk payment times out, the MTP payment is marked as failed and the system now sends an apology email to the sender.