### PR TITLE
Mark cancelled payments as 'rejected'

### DIFF
--- a/mtp_send_money/apps/send_money/payments.py
+++ b/mtp_send_money/apps/send_money/payments.py
@@ -323,8 +323,9 @@ class PaymentClient:
             received_at = self.get_govuk_capture_time(govuk_payment)
             payment_attr_updates['received_at'] = received_at.isoformat()
             payment_attr_updates['status'] = 'taken'
+        elif govuk_status == GovUkPaymentStatus.cancelled:
+            payment_attr_updates['status'] = 'rejected'
         else:
-            # TODO: we need a new mtp status for cancelled payments... 'cancelled'
             # TODO: if timed_out_after_capturable, failed payment and failed credit
             payment_attr_updates['status'] = 'failed'
 

--- a/mtp_send_money/apps/send_money/tests/test_commands.py
+++ b/mtp_send_money/apps/send_money/tests/test_commands.py
@@ -40,7 +40,7 @@ class UpdateIncompletePaymentsTestCase(SimpleTestCase):
         - wargle-3333 relates to a GOV.UK payment in 'failed' status without being in capturable status in the past
             so should become 'failed'
         - wargle-4444 relates to a GOV.UK payment in 'cancelled' status so:
-            * should become 'failed'
+            * should become 'rejected'
             * a notification email should be sent to the sender
         - wargle-5555 relates to a GOV.UK payment in 'failed' status which was in a capturable status in the past so:
             * should become 'failed'
@@ -365,7 +365,7 @@ class UpdateIncompletePaymentsTestCase(SimpleTestCase):
                 json.loads(rsps.calls[9].request.body.decode()),
                 {
                     'email': 'cancelled_sender@outside.local',
-                    'status': 'failed',
+                    'status': 'rejected',
                 },
             )
             self.assertEqual(


### PR DESCRIPTION
MTP payments related to govuk payments in status `cancelled` are now marked as `rejected` instead of `failed` so that they don't get automatically deleted by the cleanup task.