### PR TITLE
MTP-1480 Remove error mentioning public prisons only

### DIFF
--- a/mtp_send_money/templates/send_money/prisoner-details-error-summary.html
+++ b/mtp_send_money/templates/send_money/prisoner-details-error-summary.html
@@ -21,13 +21,6 @@
           {% trans 'Please check:' %}
             <ul class="list list-bullet">
               <li>{% trans 'you entered the details correctly' %}</li>
-              <li>
-                {% url 'help_area:prison_list' as prison_list_url %}
-                {% blocktrans trimmed %}
-                  you’re sending money to a <a href="{{ prison_list_url }}">public prison</a>
-                {% endblocktrans %}
-              </li>
-
               <li>{% trans 'the details match those held by the prison - ask the prisoner to check with the wing officer' %}</li>
             </ul>
         </li>


### PR DESCRIPTION
In June we enabled our service for all but one[1] private estate prisons
however the error message on checking correct prisoner details still
told a user to check they are trying to send money to a public prison.

This commit removes the error message related to only public prisons
using our service.
