### PR TITLE
MTP-1532 Remove email confirmation promise

### DIFF
--- a/mtp_send_money/templates/send_money/debit-card-confirmation.html
+++ b/mtp_send_money/templates/send_money/debit-card-confirmation.html
@@ -48,7 +48,6 @@
           {% trans 'Please check your spam folder.' %}
         </li>
         <li>{% trans 'Money usually takes less than 3 working days to reach a prisoner’s account, but may take longer.' %}</li>
-        <li>{% trans 'You’ll get a further email when the prisoner’s account has been credited to confirm your money has arrived.' %}</li>
       </ol>
 
       <p>

--- a/mtp_send_money/templates/send_money/email/debit-card-confirmation.html
+++ b/mtp_send_money/templates/send_money/email/debit-card-confirmation.html
@@ -14,7 +14,6 @@
 
   <p>
     {% trans 'Money should reach the prisoner’s account in up to 3 working days.' %}
-    {% trans 'You’ll get a further email when the prisoner’s account has been credited to confirm your money has arrived.' %}
   </p>
 
   <table cellspacing="10" style="font-family: sans-serif; border-left: 10px solid #b1b4b6; padding-left: 15px;">

--- a/mtp_send_money/templates/send_money/email/debit-card-confirmation.txt
+++ b/mtp_send_money/templates/send_money/email/debit-card-confirmation.txt
@@ -7,7 +7,6 @@ GOV.UK - {% trans 'Send money to someone in prison' %}
 {% trans 'Your payment has been successful.' %} {% blocktrans trimmed %}Your confirmation number is {{ short_payment_ref }}.{% endblocktrans %}
 
 {% trans 'Money should reach the prisoner’s account in up to 3 working days.' %}
-{% trans 'You’ll get a further email when the prisoner’s account has been credited to confirm your money has arrived.' %}
 
 {% trans 'Payment to:' %} {{ prisoner_name }}
 {% trans 'Amount:' %} {{ amount|currency_format }}


### PR DESCRIPTION
Jira: https://dsdmoj.atlassian.net/browse/MTP-1532

We can only send this email about money hitting a prisoners account when
prison staff use the cash book to accept a payment. Private prisons do
not use the cash book service however, but manage accounts in the
Custody Management System (CMS).

Now we have more private prisons in our system, we want to remove this
information about getting a second confirmation email when money hits a
prisoners account, until we can determine if we can determine when a
prisoner actually gets the money credited to their accounts.