### PR TITLE
MTP-1469 Moved local.py dockerignore out of root defintion and added it within CI task instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
           name: Build docker image
           command: |
             source /tmp/mtp-env.sh
+            echo 'mtp_send_money/settings/local.py' >> .dockerignore
             docker build \
               --force-rm \
               --build-arg APP_GIT_COMMIT=${CIRCLE_SHA1} \

--- a/.dockerignore
+++ b/.dockerignore
@@ -22,7 +22,6 @@ package.json
 package-lock.json
 webpack.config.js
 mtp_send_money/assets/
-mtp_send_money/settings/local.py
 mtp_send_money/templates/govuk_template
 static/
 media/


### PR DESCRIPTION

a) this shouldn't be really necessary as it's already in the .gitignore b) docker-compose does support custom .dockerignore to dockerfile mapping, but it doesn't seem to actually work right now (see comments under ticked answer on https://stackoverflow.com/questions/40904409/how-to-specify-different-dockerignore-files-for-different-builds-in-the-same-pr