### PR TITLE
Remove reference to "safe" limit when capping is enabled

### DIFF
--- a/mtp_send_money/apps/send_money/forms.py
+++ b/mtp_send_money/apps/send_money/forms.py
@@ -213,7 +213,7 @@ class DebitCardAmountForm(SendMoneyForm):
         'connection': _('This service is currently unavailable'),
         'missing_prisoner_number': _('This service is currently unavailable'),
         'cap_exceeded': _(
-            'You can’t send money to this person’s account. It has reached its safe limit for now. '
+            'You can’t send money to this person’s account. It has reached its limit for now. '
             'Please follow up with them about it.'
         )
     }

--- a/mtp_send_money/apps/send_money/tests/test_views.py
+++ b/mtp_send_money/apps/send_money/tests/test_views.py
@@ -617,7 +617,7 @@ class DebitCardAmountTestCase(DebitCardFlowTestCase):
             )
 
             response = self.client.post(self.url, data={'amount': '100'}, follow=True)
-            self.assertContains(response, 'It has reached its safe limit for now')
+            self.assertContains(response, 'It has reached its limit for now')
             form = response.context['form']
             self.assertTrue(form.errors)
 


### PR DESCRIPTION
It was decided that "safe" would be confusing.

[MTP-1465](https://dsdmoj.atlassian.net/browse/MTP-1465?focusedCommentId=111785)