### PR TITLE
Improve table accessibility based on SonarQube recommendations

### DIFF
--- a/mtp_send_money/templates/cookies.html
+++ b/mtp_send_money/templates/cookies.html
@@ -65,9 +65,9 @@
       <table>
         <thead>
           <tr>
-            <th>{% trans 'Name' %}</th>
-            <th>{% trans 'Purpose' %}</th>
-            <th>{% trans 'Expires' %}</th>
+            <th scope="col">{% trans 'Name' %}</th>
+            <th scope="col">{% trans 'Purpose' %}</th>
+            <th scope="col">{% trans 'Expires' %}</th>
           </tr>
         </thead>
         <tbody>
@@ -99,9 +99,9 @@
       <table>
         <thead>
           <tr>
-            <th>{% trans 'Name' %}</th>
-            <th>{% trans 'Purpose' %}</th>
-            <th>{% trans 'Expires' %}</th>
+            <th scope="col">{% trans 'Name' %}</th>
+            <th scope="col">{% trans 'Purpose' %}</th>
+            <th scope="col">{% trans 'Expires' %}</th>
           </tr>
         </thead>
         <tbody>
@@ -126,9 +126,9 @@
       <table>
         <thead>
           <tr>
-            <th>{% trans 'Name' %}</th>
-            <th>{% trans 'Purpose' %}</th>
-            <th>{% trans 'Expires' %}</th>
+            <th scope="col">{% trans 'Name' %}</th>
+            <th scope="col">{% trans 'Purpose' %}</th>
+            <th scope="col">{% trans 'Expires' %}</th>
           </tr>
         </thead>
         <tbody>

--- a/mtp_send_money/templates/cookies.html
+++ b/mtp_send_money/templates/cookies.html
@@ -61,8 +61,8 @@
         <li>{% trans 'what you enter into pages on this site' %}</li>
       </ul>
 
-      <p>{% trans 'Google Analytics sets the following cookies:' %}</p>
-      <table>
+      <p id="table-caption-ga">{% trans 'Google Analytics sets the following cookies:' %}</p>
+      <table aria-describedby="table-caption-ga">
         <thead>
           <tr>
             <th scope="col">{% trans 'Name' %}</th>
@@ -92,11 +92,11 @@
       </p>
 
       <h3 class="heading-medium">{% trans 'Your progress when using the service' %}</h3>
-      <p>
+      <p id="table-caption-service">
         {% trans 'When you use the ‘Send money to someone in prison’ service, we’ll set cookies to remember your progress through this site.' %}
         {% trans 'These cookies don’t store your personal data and are deleted when you close this website.' %}
       </p>
-      <table>
+      <table aria-describedby="table-caption-service">
         <thead>
           <tr>
             <th scope="col">{% trans 'Name' %}</th>
@@ -119,11 +119,11 @@
       </table>
 
       <h3 class="heading-medium">{% trans 'Settings you’ve chosen' %}</h3>
-      <p>
+      <p id="table-caption-settings">
         {% trans 'When you use the ‘Send money to someone in prison’ service, we’ll set cookies to remember settings you change.' %}
         {% trans 'These cookies don’t store any personal data, but will be saved on your computer or mobile for some time.' %}
       </p>
-      <table>
+      <table aria-describedby="table-caption-settings">
         <thead>
           <tr>
             <th scope="col">{% trans 'Name' %}</th>

--- a/mtp_send_money/templates/send_money/bank-transfer-reference.html
+++ b/mtp_send_money/templates/send_money/bank-transfer-reference.html
@@ -45,19 +45,19 @@
               <table>
                 <tbody>
                   <tr>
-                    <th>{% trans 'Account number:' %}</th>
+                    <th scope="row">{% trans 'Account number:' %}</th>
                     <td>{{ account_number }}</td>
                   </tr>
                   <tr>
-                    <th>{% trans 'Sort code:'%}</th>
+                    <th scope="row">{% trans 'Sort code:'%}</th>
                     <td>{{ sort_code }}</td>
                   </tr>
                   <tr>
-                    <th>{% trans 'Reference:' %}</th>
+                    <th scope="row">{% trans 'Reference:' %}</th>
                     <td>{{ bank_transfer_reference }}</td>
                   </tr>
                   <tr>
-                    <th>{% trans 'Payee/Name:' %}</th>
+                    <th scope="row">{% trans 'Payee/Name:' %}</th>
                     <td>{{ bank_transfer_reference }}</td>
                   </tr>
                 </tbody>

--- a/mtp_send_money/templates/send_money/bank-transfer-reference.html
+++ b/mtp_send_money/templates/send_money/bank-transfer-reference.html
@@ -40,9 +40,11 @@
           </li>
 
           <li>
-            {% trans 'Copy and paste these details into the transfer:' %}
+            <span id="table-caption-transfer-details">
+              {% trans 'Copy and paste these details into the transfer:' %}
+            </span>
             <div class="mtp-account panel panel-border-wide">
-              <table>
+              <table aria-describedby="table-caption-transfer-details">
                 <tbody>
                   <tr>
                     <th scope="row">{% trans 'Account number:' %}</th>

--- a/mtp_send_money/templates/send_money/debit-card-check.html
+++ b/mtp_send_money/templates/send_money/debit-card-check.html
@@ -19,8 +19,8 @@
       <section class="mtp-check-details">
         <div class="grid-row">
           <div class="column-two-thirds">
-            <h2 class="heading-medium">{% trans 'Prisoner details' %}</h2>
-            <table class="mtp-check-table">
+            <h2 class="heading-medium" id="table-caption-prisoner">{% trans 'Prisoner details' %}</h2>
+            <table class="mtp-check-table" aria-describedby="table-caption-prisoner">
               <tbody>
                 <tr>
                   <th scope="row">{% trans 'Name' %}:</th>
@@ -48,8 +48,8 @@
       <section class="mtp-check-details">
         <div class="grid-row">
           <div class="column-two-thirds">
-            <h2 class="heading-medium">{% trans 'Amount' %}</h2>
-            <table class="mtp-check-table">
+            <h2 class="heading-medium" id="table-caption-amount">{% trans 'Amount' %}</h2>
+            <table class="mtp-check-table" aria-describedby="table-caption-amount">
               <tbody>
                 {% if service_charged %}
                   <tr>

--- a/mtp_send_money/templates/send_money/debit-card-check.html
+++ b/mtp_send_money/templates/send_money/debit-card-check.html
@@ -23,15 +23,15 @@
             <table class="mtp-check-table">
               <tbody>
                 <tr>
-                  <th>{% trans 'Name' %}:</th>
+                  <th scope="row">{% trans 'Name' %}:</th>
                   <td>{{ prisoner_name }}</td>
                 </tr>
                 <tr>
-                  <th>{% trans 'Date of birth' %}:</th>
+                  <th scope="row">{% trans 'Date of birth' %}:</th>
                   <td>{{ prisoner_dob|prepare_prisoner_dob|date:'d/m/Y' }}</td>
                 </tr>
                 <tr>
-                  <th>{% trans 'Prisoner number' %}:</th>
+                  <th scope="row">{% trans 'Prisoner number' %}:</th>
                   <td>{{ prisoner_number }}</td>
                 </tr>
               </tbody>
@@ -53,20 +53,20 @@
               <tbody>
                 {% if service_charged %}
                   <tr>
-                    <th>{% trans 'Total to prisoner' %}:</th>
+                    <th scope="row">{% trans 'Total to prisoner' %}:</th>
                     <td>
                       {{ amount|currency_format }}
                     </td>
                   </tr>
                   <tr>
-                    <th>{% trans 'Amount to be taken from your account' %}:</th>
+                    <th scope="row">{% trans 'Amount to be taken from your account' %}:</th>
                     <td>
                       {{ amount|add_service_charge|currency_format }}
                     </td>
                   </tr>
                 {% else %}
                   <tr>
-                    <th>{% trans 'Total' %}:</th>
+                    <th scope="row">{% trans 'Total' %}:</th>
                     <td>
                       {{ amount|currency_format }}
                     </td>

--- a/mtp_send_money/templates/send_money/debit-card-confirmation.html
+++ b/mtp_send_money/templates/send_money/debit-card-confirmation.html
@@ -22,19 +22,19 @@
         <table>
           <tbody>
             <tr>
-              <th>{% trans 'Payment to' %}:</th>
+              <th scope="row">{% trans 'Payment to' %}:</th>
               <td>{{ prisoner_name }}</td>
             </tr>
             <tr>
-              <th>{% trans 'Amount' %}:</th>
+              <th scope="row">{% trans 'Amount' %}:</th>
               <td>{{ amount|currency_format }}</td>
             </tr>
             <tr>
-              <th>{% trans 'Date payment made' %}:</th>
+              <th scope="row">{% trans 'Date payment made' %}:</th>
               <td>{% now 'd/m/Y' %}</td>
             </tr>
             <tr>
-              <th>{% trans 'Confirmation number' %}:</th>
+              <th scope="row">{% trans 'Confirmation number' %}:</th>
               <td>{{ short_payment_ref }}</td>
             </tr>
           </tbody>

--- a/mtp_send_money/templates/send_money/debit-card-confirmation.html
+++ b/mtp_send_money/templates/send_money/debit-card-confirmation.html
@@ -20,6 +20,9 @@
     <div class="column-two-thirds">
       <div class="mtp-account panel panel-border-wide">
         <table>
+          <caption class="visually-hidden">
+            {% trans 'Details of your payment' %}
+          </caption>
           <tbody>
             <tr>
               <th scope="row">{% trans 'Payment to' %}:</th>

--- a/mtp_send_money/templates/send_money/debit-card-on-hold.html
+++ b/mtp_send_money/templates/send_money/debit-card-on-hold.html
@@ -21,19 +21,19 @@
         <table>
           <tbody>
             <tr>
-              <th>{% trans 'Payment to' %}:</th>
+              <th scope="row">{% trans 'Payment to' %}:</th>
               <td>{{ prisoner_name }} ( {{ prisoner_number }})</td>
             </tr>
             <tr>
-              <th>{% trans 'Amount' %}:</th>
+              <th scope="row">{% trans 'Amount' %}:</th>
               <td>{{ amount|currency_format }}</td>
             </tr>
             <tr>
-              <th>{% trans 'Date' %}:</th>
+              <th scope="row">{% trans 'Date' %}:</th>
               <td>{% now 'd/m/Y' %}</td>
             </tr>
             <tr>
-              <th>{% trans 'Reference' %}:</th>
+              <th scope="row">{% trans 'Reference' %}:</th>
               <td>{{ short_payment_ref }}</td>
             </tr>
           </tbody>

--- a/mtp_send_money/templates/send_money/debit-card-on-hold.html
+++ b/mtp_send_money/templates/send_money/debit-card-on-hold.html
@@ -19,6 +19,9 @@
     <div class="column-two-thirds">
       <div class="mtp-account panel panel-border-wide">
         <table>
+          <caption class="visually-hidden">
+            {% trans 'Details of your payment' %}
+          </caption>
           <tbody>
             <tr>
               <th scope="row">{% trans 'Payment to' %}:</th>


### PR DESCRIPTION
- `th` elements should indicate row/column direction (or be linked by id; but we've not needed to)
- describe tables by either
    - adding a hidden caption where no label-like-thing exists nearby
    - using ARIA attribute to link to nearby label-like-thing (so that screen readers do not read the label and then a duplicate caption)

---

This ignores tables in emails for the time being. I've no idea whether scope/aria attributes 1) work in some/any email clients 2) don't break layout/readability in older email clients