### PR TITLE
MTP-1560 Add quotes to accessibility page heading

### DIFF
--- a/mtp_send_money/templates/accessibility.html
+++ b/mtp_send_money/templates/accessibility.html
@@ -6,7 +6,7 @@
 
 {% block inner_content %}
   <header>
-    <h1 class="heading-xlarge">{% trans 'Accessibility statement for the Send money to someone in prison service' %}</h1>
+    <h1 class="heading-xlarge">{% trans 'Accessibility statement for the ‘Send money to someone in prison’ service' %}</h1>
   </header>
 
   <div class="grid-row">


### PR DESCRIPTION
Our team Content designer has suggested including quotes in the page
heading so that it's easier to read which part of the title is the
service this accessibility statement applies to.