### PR TITLE
MTP-1614 Add warning standing orders will also stop

### DIFF
--- a/mtp_send_money/templates/send_money/payment-method.html
+++ b/mtp_send_money/templates/send_money/payment-method.html
@@ -19,7 +19,7 @@
         {% trans 'From November 2nd, you will no longer be able to:' %}
       </p>
       <ul class="list list-bullet">
-        <li>{% trans 'send money by bank transfer' %}</li>
+        <li>{% trans 'send money by bank transfer or standing order' %}</li>
         <li>{% trans 'send in cash, cheques or postal orders by post' %}</li>
       </ul>
       <p>


### PR DESCRIPTION
JIRA: https://dsdmoj.atlassian.net/browse/MTP-1614

When bank transfers stop on November 2nd 2020 we need to also note that
this means that standing orders will also stop.