### PR TITLE
No debit card page - MTP-1617 No debit card page warning standing orders will stop

### DIFF
--- a/mtp_send_money/templates/send_money/bank-transfer-warning.html
+++ b/mtp_send_money/templates/send_money/bank-transfer-warning.html
@@ -12,7 +12,7 @@
     </h1>
     <div class="mtp-notification__message" style="display:block">
       <p>
-        {% trans 'From November 2nd, you will no longer be able to send money by bank transfer.' %}
+        {% trans 'From November 2nd, you will no longer be able to send money by bank transfer or standing order.' %}
         {% trans 'You will not be able to send in cash, cheques or postal orders by post either.' %}
       </p>
       <p>


### PR DESCRIPTION

NB: **I'm going to maybe add the further change mentioned in Slack to this PR is it's a go: https://mojdt.slack.com/archives/C58KXKE84/p1601891552002200**

----------


JIRA: https://dsdmoj.atlassian.net/browse/MTP-1617

When bank transfers stop on November 2nd 2020 we need to also note that
this means that standing orders will also stop. This change is for the
"Don't have a debit card page".
