### PR TITLE
Emphasize waiting time when payment fails

### DIFF
--- a/mtp_send_money/templates/send_money/debit-card-declined.html
+++ b/mtp_send_money/templates/send_money/debit-card-declined.html
@@ -10,12 +10,8 @@
 </header>
 
 <p>{% trans 'No money has been taken from your account.' %}</p>
-
-<p>{% trans 'What next?' %}</p>
-
-<ul class="list list-bullet">
-  <li>{% trans 'Wait 5 days before you try to make another payment or your card could be declined again' %}</li>
-  <li>{% trans 'Check that the address and other card details are exactly the same as your bank holds' %}</li>
-  <li>{% trans 'Check with your bank for any problems with your card' %}</li>
-</ul>
+<p>
+  {% trans '<strong>You must wait 5 days </strong> before trying to make another payment, even if you have money in the bank.' %}
+</p>
+<p>{% trans 'In the meantime, check that the address and other card details are exactly the same as your bank holds.' %}</p>
 {% endblock %}


### PR DESCRIPTION
This change is intended to reduce the number of people re-trying failed payments many times (as this can eventually lead to support calls to the service team).

New copy:

![image](https://user-images.githubusercontent.com/429326/98959016-ca562800-24fa-11eb-8051-475eb43676f9.png)

(JIRA: MTP-1640)