### PR TITLE
Add semantic HTML to buttons for Check Details page

### DIFF
--- a/mtp_send_money/templates/send_money/debit-card-check.html
+++ b/mtp_send_money/templates/send_money/debit-card-check.html
@@ -92,10 +92,10 @@
 
   <div class="grid-row mtp-check-details__confirm">
     <form class="column-one-third" action="{{ view.get_success_url }}" method="get">
-      <input class="button" id="id_next_btn" type="submit" value="{% trans 'Enter card details' %}">
+      <p><input class="button" id="id_next_btn" type="submit" value="{% trans 'Enter card details' %}"></p>
     </form>
     <form class="column-two-thirds" action="{% url 'send_money:clear_session' %}" method="get">
-      <input class="link" type="submit" value="{% trans 'Cancel and delete all details' %}">
+      <p><input class="link" type="submit" value="{% trans 'Cancel and delete all details' %}"></p>
     </form>
   </div>
 


### PR DESCRIPTION
Jira: https://dsdmoj.atlassian.net/browse/MTP-1702

On the Check details page in the send money flow, the check details page
buttons "Enter Card Details" and "Cancel and delete all details" buttons
were read out in a single 'breath' by JAWS, with no pause to identify
them as separate input items.

This commit adds some semantic HTML around them so that screenreaders
can distinguish them as separate elements.