### PR TITLE
Fix error message when prisoner details were incorrectly entered

### DIFF
--- a/mtp_send_money/templates/send_money/prisoner-details-error-summary.html
+++ b/mtp_send_money/templates/send_money/prisoner-details-error-summary.html
@@ -27,10 +27,10 @@
               {% trans 'Ask the person in prison to check with their wing officer that your details match theirs' %}
             </li>
             <li>
-              {% trans 'If the prison details are wrong, write to the prison to get them corrected' %}
+              {% trans 'If your details are wrong, use the new details you’ve been given' %}
             </li>
             <li>
-              {% trans 'If your details are wrong, use the new details you’ve been given' %}
+              {% trans 'If the prison details are wrong, the person in prison needs to submit a general application to the Offender Management Unit querying their details' %}
             </li>
           </ul>
         </li>


### PR DESCRIPTION
…because the sender cannot request them to be corrected in NOMIS nor be given them directly. It's only the prisoner who can request changes.
[MTP-1694](https://dsdmoj.atlassian.net/browse/MTP-1694)