### PR TITLE
Remove payment method choice from *new* payment query form

### DIFF
--- a/mtp_send_money/apps/help_area/forms.py
+++ b/mtp_send_money/apps/help_area/forms.py
@@ -54,22 +54,6 @@ class ContactNewPaymentForm(ContactForm):
         label=_('Your name'),
         validators=[RejectCardNumberValidator()],
     )
-    payment_method = forms.ChoiceField(
-        label=_('Type of payment'),
-        choices=(
-            ('debit_card', _('Debit card')),
-            ('bank_transfer', _('Bank transfer')),
-        ),
-    )
-
-    def clean_payment_method(self):
-        payment_method = self.cleaned_data.get('payment_method')
-        if payment_method:
-            for value, name in self.fields['payment_method'].choices:
-                if value == payment_method:
-                    self.cleaned_data['payment_method_name'] = name
-                    break
-        return payment_method
 
 
 class ContactSentPaymentForm(ContactNewPaymentForm):
@@ -83,10 +67,26 @@ class ContactSentPaymentForm(ContactNewPaymentForm):
             'max_decimal_places': _('Only use 2 decimal places'),
         }
     )
+    payment_method = forms.ChoiceField(
+        label=_('Type of payment'),
+        choices=(
+            ('debit_card', _('Debit card')),
+            ('bank_transfer', _('Bank transfer')),
+        ),
+    )
     payment_date = SplitDateField(
         label=_('Date of payment'),
         help_text=_('For example, 8 6 2020'),
     )
+
+    def clean_payment_method(self):
+        payment_method = self.cleaned_data.get('payment_method')
+        if payment_method:
+            for value, name in self.fields['payment_method'].choices:
+                if value == payment_method:
+                    self.cleaned_data['payment_method_name'] = name
+                    break
+        return payment_method
 
     def clean_payment_date(self):
         payment_date = self.cleaned_data.get('payment_date')

--- a/mtp_send_money/apps/help_area/tests/test_contact_us.py
+++ b/mtp_send_money/apps/help_area/tests/test_contact_us.py
@@ -20,7 +20,6 @@ class ContactUsTestCase(BaseTestCase):
         'ticket_content': 'I’d like some help',
         'contact_name': 'Ms Smith',
         'contact_email': 's.smith@localhost',
-        'payment_method': 'debit_card',
         'prisoner_number': 'A1401AE',
         'prisoner_dob_0': '21',
         'prisoner_dob_1': '1',
@@ -103,7 +102,6 @@ class ContactUsTestCase(BaseTestCase):
         self.assertIn('s.smith@localhost', ticket_body)
         self.assertIn('A1401AE', ticket_body)
         self.assertIn('21/01/1989', ticket_body)
-        self.assertIn('Debit card', ticket_body)
 
     @mock.patch('zendesk_tickets.client.create_ticket')
     def test_fields_in_sent_payment_ticket(self, mocked_create_ticket):

--- a/mtp_send_money/templates/help_area/contact-new-payment-ticket.txt
+++ b/mtp_send_money/templates/help_area/contact-new-payment-ticket.txt
@@ -9,4 +9,4 @@ Sender name: {{ contact_name|safe }}
 Sender email: {{ contact_email|safe }}
 Prisoner number: {{ prisoner_number|safe }}
 Prisoner date of birth: {{ prisoner_dob|date:'SHORT_DATE_FORMAT'|safe }}
-Payment method: {{ payment_method_name|safe }}
+Payment method: Debit card

--- a/mtp_send_money/templates/help_area/contact-new-payment.html
+++ b/mtp_send_money/templates/help_area/contact-new-payment.html
@@ -42,13 +42,6 @@
 
             {% include 'mtp_common/forms/field.html' with field=form.contact_name only %}
             {% include 'mtp_common/forms/field.html' with field=form.contact_email value=request.GET.email|default:'' only %}
-
-            <fieldset class="inline">
-              <legend>
-                {{ form.payment_method.label }}
-              </legend>
-              {% include 'mtp_common/forms/radio-field.html' with field=form.payment_method only %}
-            </fieldset>
           {% endblock %}
 
           {% with field=form.ticket_content value=request.GET.message|default:'' %}

--- a/mtp_send_money/templates/help_area/contact-sent-payment.html
+++ b/mtp_send_money/templates/help_area/contact-sent-payment.html
@@ -26,6 +26,13 @@
   {{ block.super }}
 
   {% with field=form.amount %}
+    <fieldset class="inline">
+      <legend>
+        {{ form.payment_method.label }}
+      </legend>
+      {% include 'mtp_common/forms/radio-field.html' with field=form.payment_method only %}
+    </fieldset>
+
     <fieldset>
       <legend class="visually-hidden">{% trans 'Please enter the amount in pounds' %}</legend>
 


### PR DESCRIPTION
…because bank transfers are no longer an option. Keep it for now on *sent* payment query form.
[MTP-1731](https://dsdmoj.atlassian.net/browse/MTP-1731)