### PR TITLE
Remove sending-money-by-post survey link from success email

### DIFF
--- a/mtp_send_money/templates/send_money/email/debit-card-confirmation.html
+++ b/mtp_send_money/templates/send_money/email/debit-card-confirmation.html
@@ -3,18 +3,6 @@
 {% load send_money %}
 
 {% block inner_content %}
-  <p>
-    <strong style="font-weight: bold">
-      {% trans 'Do you, or someone you know, send in money by cash, cheque or postal order?' %}
-    </strong>
-  </p>
-  <p>
-    {% blocktrans trimmed with link='https://docs.google.com/forms/d/e/1FAIpQLScsTPe2OJrXxqRwlphnm-LItBe-BbZ3STSRARzc4KNpPvjx0g/viewform' %}
-      If so, <a href="{{ link }}">let us know here</a> so we can get in touch about changes to the service.
-    {% endblocktrans %}
-  </p>
-  <hr size="1" />
-
   <p>{% trans 'Dear sender,' %}</p>
 
   <p>

--- a/mtp_send_money/templates/send_money/email/debit-card-confirmation.txt
+++ b/mtp_send_money/templates/send_money/email/debit-card-confirmation.txt
@@ -2,12 +2,6 @@
 {% load send_money %}
 GOV.UK - {% trans 'Send money to someone in prison' %}
 
-
-* {% trans 'Do you, or someone you know, send in money by cash, cheque or postal order?' %} *
-{% trans 'If so, let us know here so we can get in touch about changes to the service' %}:
-https://docs.google.com/forms/d/e/1FAIpQLScsTPe2OJrXxqRwlphnm-LItBe-BbZ3STSRARzc4KNpPvjx0g/viewform
-
-
 {% trans 'Dear sender,' %}
 
 {% trans 'Your payment has been successful.' %} {% blocktrans trimmed %}Your confirmation number is {{ short_payment_ref }}.{% endblocktrans %}


### PR DESCRIPTION
… because there have been many responses and it's been 2 months since money by post has been allowed by exemption only.
(Revert commit b2cdf2c6051bf9169efb51891adab00dba75dea3)
[MTP-1769](https://dsdmoj.atlassian.net/browse/MTP-1769)