### PR TITLE
Make old contact us form inaccessible by redirecting to the help landing page

### DIFF
--- a/mtp_send_money/apps/help_area/tests/test_contact_us.py
+++ b/mtp_send_money/apps/help_area/tests/test_contact_us.py
@@ -42,7 +42,8 @@ class ContactUsTestCase(BaseTestCase):
     }
 
     forms = {
-        'generic': (contact_us_url, sample_submission),
+        # NB: the "generic" (help with the service in general) view is now inaccessible
+        # 'generic': (contact_us_url, sample_submission),
         'new_payment': (contact_us_new_payment_url, new_payment_sample_submission),
         'sent_payment': (contact_us_sent_payment_url, sent_payment_sample_submission),
     }
@@ -50,6 +51,17 @@ class ContactUsTestCase(BaseTestCase):
     def test_legacy_url_name(self):
         url = reverse('submit_ticket')
         self.assertTrue(url, msg='Unnamespaced `submit_ticket` url name should exist for mtp-common compatibility')
+
+    def test_old_links_redirect_to_help_landing_page(self):
+        old_links = [
+            # original url (there are probably no links there anymore)
+            '/feedback/',
+            # former "generic" form (this link is still around but should no longer point to the generic form)
+            '/contact-us/',
+        ]
+        for link in old_links:
+            response = self.client.get(link, follow=True)
+            self.assertEqual(response.resolver_match.view_name, 'help_area:help')
 
     def test_sample_submissions(self):
         for conf in self.forms.values():

--- a/mtp_send_money/apps/help_area/urls.py
+++ b/mtp_send_money/apps/help_area/urls.py
@@ -57,7 +57,7 @@ urlpatterns = [
     url(r'^help/faq/$', CacheableTemplateView.as_view(template_name='help_area/faq.html'), name='faq'),
 
     url(r'^contact-us/$',
-        RedirectView.as_view(url=reverse_lazy('help_area:help'), permanent=True),
+        RedirectView.as_view(url=reverse_lazy('help_area:help'), permanent=False),
         name='submit_ticket'),
     url(r'^contact-us/success/$', views.ContactSuccessView.as_view(), name='feedback_success'),
     url(r'^help/with-making-a-payment/contact-us/$',

--- a/mtp_send_money/apps/help_area/urls.py
+++ b/mtp_send_money/apps/help_area/urls.py
@@ -56,7 +56,9 @@ urlpatterns = [
 
     url(r'^help/faq/$', CacheableTemplateView.as_view(template_name='help_area/faq.html'), name='faq'),
 
-    url(r'^contact-us/$', views.ContactView.as_view(), name='submit_ticket'),
+    url(r'^contact-us/$',
+        RedirectView.as_view(url=reverse_lazy('help_area:help'), permanent=True),
+        name='submit_ticket'),
     url(r'^contact-us/success/$', views.ContactSuccessView.as_view(), name='feedback_success'),
     url(r'^help/with-making-a-payment/contact-us/$',
         views.ContactNewPaymentView.as_view(),

--- a/mtp_send_money/apps/help_area/views.py
+++ b/mtp_send_money/apps/help_area/views.py
@@ -16,6 +16,9 @@ logger = logging.getLogger('mtp')
 
 
 class ContactView(BaseGetHelpView):
+    """
+    Contact us page for general queries/feedback: does not ask for additional information about payments
+    """
     form_class = ContactForm
     success_url = reverse_lazy('help_area:feedback_success')
     template_name = 'help_area/contact.html'
@@ -33,6 +36,9 @@ class ContactView(BaseGetHelpView):
 
 
 class ContactNewPaymentView(ContactView):
+    """
+    Contact us page for queries about making a payment: asks for additional information
+    """
     form_class = ContactNewPaymentForm
     template_name = 'help_area/contact-new-payment.html'
     page_title = _('Help with making a payment')
@@ -41,6 +47,9 @@ class ContactNewPaymentView(ContactView):
 
 
 class ContactSentPaymentView(ContactView):
+    """
+    Contact us page for queries about a payment already made: asks for additional information
+    """
     form_class = ContactSentPaymentForm
     template_name = 'help_area/contact-sent-payment.html'
     page_title = _('Help with a payment I’ve already made')
@@ -49,6 +58,9 @@ class ContactSentPaymentView(ContactView):
 
 
 class ContactSuccessView(BaseGetHelpSuccessView):
+    """
+    Success page for all contact us routes
+    """
     template_name = 'help_area/contact-success.html'
 
     def get_context_data(self, **kwargs):
@@ -57,6 +69,9 @@ class ContactSuccessView(BaseGetHelpSuccessView):
 
 
 class HelpView(CacheableTemplateView):
+    """
+    Pages in the help area without forms
+    """
     back_url = None
 
     def get_context_data(self, **kwargs):

--- a/mtp_send_money/apps/help_area/views.py
+++ b/mtp_send_money/apps/help_area/views.py
@@ -18,6 +18,7 @@ logger = logging.getLogger('mtp')
 class ContactView(BaseGetHelpView):
     """
     Contact us page for general queries/feedback: does not ask for additional information about payments
+    NB: no longer accessible, but retained in case needed in future
     """
     form_class = ContactForm
     success_url = reverse_lazy('help_area:feedback_success')

--- a/mtp_send_money/apps/send_money/tests/test_functional.py
+++ b/mtp_send_money/apps/send_money/tests/test_functional.py
@@ -163,11 +163,11 @@ class SendMoneyCheckDetailsPage(SendMoneyFunctionalTestCase):
 
 class SendMoneyFeedbackPages(SendMoneyFunctionalTestCase):
     def test_feedback_page(self):
-        self.driver.get(self.live_server_url + '/en-gb/contact-us/')
-        self.assertInSource('Enter your questions or feedback')
+        self.driver.get(self.live_server_url + '/help/with-making-a-payment/contact-us/')
+        self.assertInSource('Contact us about a payment you are finding it difficult to make')
 
     def test_feedback_received_page(self):
-        self.driver.get(self.live_server_url + '/en-gb/contact-us/success/')
+        self.driver.get(self.live_server_url + '/contact-us/success/')
         self.assertInSource('Thank you')
 
 

--- a/mtp_send_money/apps/send_money/views_misc.py
+++ b/mtp_send_money/apps/send_money/views_misc.py
@@ -110,7 +110,7 @@ class SitemapXMLView(TemplateView):
 
 
 class LegacyFeedbackView(RedirectView):
-    url = reverse_lazy('help_area:submit_ticket')
+    url = reverse_lazy('help_area:help')
     permanent = True
 
     def dispatch(self, request, *args, **kwargs):


### PR DESCRIPTION
It was still technically possible (knowing the URL) to end up on the contact form that did not collect any details about a payment.

[MTP-1802](https://dsdmoj.atlassian.net/browse/MTP-1802)