### PR TITLE
Remove payment ID from GOV.UK Pay Exceptions message

### DIFF
--- a/mtp_send_money/apps/send_money/payments.py
+++ b/mtp_send_money/apps/send_money/payments.py
@@ -191,13 +191,18 @@ class PaymentClient:
             return
 
         if govuk_status == GovUkPaymentStatus.error:
+            error_code = govuk_payment.get('state', {}).get('code')
+            error_msg = govuk_payment.get('state', {}).get('message')
+
             logger.error(
-                'GOV.UK Pay returned an error for %(govuk_id)s: %(code)s %(msg)s' %
+                f'GOV.UK Pay returned an error: {error_code} {error_msg}',
                 {
-                    'govuk_id': govuk_payment.get('payment_id') or payment['uuid'],
-                    'code': govuk_payment.get('state', {}).get('code'),
-                    'msg': govuk_payment.get('state', {}).get('message'),
-                },
+                    'code': error_code,
+                    'msg': error_msg,
+                    # Additional context for Sentry issue
+                    'govuk_id': govuk_payment.get('payment_id'),
+                    'payment_uuid': payment.get('uuid'),
+                }
             )
 
         successfulish = govuk_status in [GovUkPaymentStatus.success, GovUkPaymentStatus.capturable]


### PR DESCRIPTION
We can get quite a bit of these exceptions at times and Sentry should
really be able to group them as they're all the same class of problem.

As the Payment ID is in the error message these are all considerate as
separate issues.

I've removed the payment ID from the error message and moved this potentially
useful information in the Sentry Context so that it's still available
in the issue but it doesn't prevent issues grouping.

**NOTE**: These errors are sent to Sentry via the `logger.error()`, I'm not
using Sentry contexts explicitly but Sentry integration is clever enough
to add the values in the dictionary passed to the logger in the Sentry
issue.

See Sentry contexts: https://develop.sentry.dev/sdk/event-payloads/contexts/

Ticket: https://dsdmoj.atlassian.net/browse/MTP-1794