### PR TITLE
MTP-1537: remove dependencies already in mtp-common

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,13 +1,3 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=11.0.0
-
-Django>2.2,<2.3
-django-anymail[mailgun]~=7.2
-requests>=2.22,<3
-transifex-client>=0.12
-uWSGI==2.0.19.1
-
-django-form-error-reporting>=0.9
-django-moj-irat>=0.6
-django-zendesk-tickets>=0.14
+money-to-prisoners-common~=11.0.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=11.0.1
+money-to-prisoners-common~=11.1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=11.0.0
+money-to-prisoners-common[testing]~=11.1.0
 
 -r base.txt
 


### PR DESCRIPTION
Bump `mtp-common` to ~`11.0.1`~ `11.1.0` and remove the dependencies already
requested there.

This is to reduce duplication and the risk of packages versions conflicts.


Ticket: https://dsdmoj.atlassian.net/browse/MTP-1537