### PR TITLE
FAQ: Removed bullet point about sending a letter

### DIFF
--- a/mtp_send_money/templates/help_area/help-new-payment.html
+++ b/mtp_send_money/templates/help_area/help-new-payment.html
@@ -37,9 +37,6 @@
             <li>
               {% trans 'If these are right, the person in prison should check with wing staff that the prison has the same details and get them corrected if not' %}
             </li>
-            <li>
-              {% trans 'If you still have a problem, write a letter to the prison asking for the details to be corrected' %}
-            </li>
           </ul>
           <p>
             {% trans 'You won’t be able to send money using our service until your details match what the prison has.' %}


### PR DESCRIPTION
Removed the following bullet point from the 'Help with'/'Making a payment'/
'[...] don't match a prisoner' section:

> If you still have a problem, write a letter to the prison asking for the
> details to be corrected.

Because it's incorrect and misleading for senders.

Ticket: https://dsdmoj.atlassian.net/browse/MTP-1771