### PR TITLE
Handle requests exceptions better

### DIFF
--- a/mtp_send_money/apps/send_money/forms.py
+++ b/mtp_send_money/apps/send_money/forms.py
@@ -136,7 +136,7 @@ class PrisonerDetailsForm(SendMoneyForm):
         except TokenExpiredError:
             pass
         except RequestException as e:
-            if e.response.status_code != 401:
+            if getattr(e.response, 'status_code', None) != 401:
                 raise
         session = self.get_api_session(reconnect=True)
         return session.get('/prisoner_validity/', params=filters).json()
@@ -262,7 +262,7 @@ class DebitCardAmountForm(SendMoneyForm):
         except TokenExpiredError:
             pass
         except RequestException as e:
-            if e.response.status_code != 401:
+            if getattr(e.response, 'status_code', None) != 401:
                 raise
         if tries < self.max_lookup_tries:
             return self.lookup_prisoner_account_balance(tries=tries + 1)


### PR DESCRIPTION
…by not assuming a response object will always be attached. It's probably that a timed-out connection never gets a response so nothing is attached to the error object.