### PR TITLE
Performance Data endpoint (GET /performance-data.csv)

### DIFF
--- a/mtp_send_money/apps/send_money/tests/test_views_misc.py
+++ b/mtp_send_money/apps/send_money/tests/test_views_misc.py
@@ -193,7 +193,8 @@ class PerformancePlatformTestCase(SimpleTestCase):
         self.assertEqual(self.response.status_code, HTTPStatus.OK)
 
     def test_csv_response_type(self):
-        self.assertEqual(self.response['Content-Type'], 'text/csv')
+        self.assertEqual(self.response['Content-Type'], 'text/csv; charset=UTF-8')
+        self.assertEqual(self.response['Content-Disposition'], 'attachment; filename="performance-data.csv"')
 
     def test_csv_response_format(self):
         csv_content = self.response.content.decode('utf8')
@@ -238,7 +239,7 @@ class PerformancePlatformTestCase(SimpleTestCase):
                 response = self.client.get(reverse_lazy('performance_platform_csv') + query_params)
 
                 self.assertEqual(response.status_code, HTTPStatus.OK)
-                self.assertEqual(response['Content-Type'], 'text/csv')
+                self.assertEqual(response['Content-Type'], 'text/csv; charset=UTF-8')
                 csv = response.content.decode('utf8')
                 self.assertEqual(csv, 'Week commencing,Transactions – total\r\n2021-06-28,100\r\n2021-07-05,200\r\n')
 
@@ -262,7 +263,7 @@ class PerformancePlatformTestCase(SimpleTestCase):
                 response = self.client.get(reverse_lazy('performance_platform_csv') + query_params)
 
                 self.assertEqual(response.status_code, HTTPStatus.OK)
-                self.assertEqual(response['Content-Type'], 'text/csv')
+                self.assertEqual(response['Content-Type'], 'text/csv; charset=UTF-8')
                 csv = response.content.decode('utf8')
                 self.assertEqual(csv, 'Week commencing,Transactions – total\r\n2021-06-28,100\r\n')
 

--- a/mtp_send_money/apps/send_money/tests/test_views_misc.py
+++ b/mtp_send_money/apps/send_money/tests/test_views_misc.py
@@ -187,7 +187,7 @@ class PerformancePlatformTestCase(SimpleTestCase):
             mock_auth(rsps)
             rsps.add(rsps.GET, f'{settings.API_URL}/performance/data/', json=api_response)
 
-            self.response = self.client.get(reverse_lazy('performance_platform_csv'))
+            self.response = self.client.get(reverse_lazy('performance_data_csv'))
 
     def test_responds_200(self):
         self.assertEqual(self.response.status_code, HTTPStatus.OK)
@@ -210,13 +210,13 @@ class PerformancePlatformTestCase(SimpleTestCase):
 
     def test_invalid_date_params(self):
         with responses.RequestsMock(), silence_logger(name='django.request'):
-            response = self.client.get(reverse_lazy('performance_platform_csv') + '?from=invalid')
+            response = self.client.get(reverse_lazy('performance_data_csv') + '?from=invalid')
             self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
             self.assertIn('Date "invalid" could not be parsed - use YYYY-MM-DD format', response.json()['errors'])
             self.assertEqual(0, get_max_age(response))
 
         with responses.RequestsMock(), silence_logger(name='django.request'):
-            response = self.client.get(reverse_lazy('performance_platform_csv') + '?from=2021-01-01&to=invalid')
+            response = self.client.get(reverse_lazy('performance_data_csv') + '?from=2021-01-01&to=invalid')
             self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
             self.assertIn('Date "invalid" could not be parsed - use YYYY-MM-DD format', response.json()['errors'])
             self.assertEqual(0, get_max_age(response))
@@ -236,7 +236,7 @@ class PerformancePlatformTestCase(SimpleTestCase):
                 rsps.add(rsps.GET, f'{settings.API_URL}/performance/data/', json=api_response)
 
                 query_params = f'?from={from_param}'
-                response = self.client.get(reverse_lazy('performance_platform_csv') + query_params)
+                response = self.client.get(reverse_lazy('performance_data_csv') + query_params)
 
                 self.assertEqual(response.status_code, HTTPStatus.OK)
                 self.assertEqual(response['Content-Type'], 'text/csv; charset=UTF-8')
@@ -260,7 +260,7 @@ class PerformancePlatformTestCase(SimpleTestCase):
                 rsps.add(rsps.GET, f'{settings.API_URL}/performance/data/', json=api_response)
 
                 query_params = f'?from={from_param}&to={to_param}'
-                response = self.client.get(reverse_lazy('performance_platform_csv') + query_params)
+                response = self.client.get(reverse_lazy('performance_data_csv') + query_params)
 
                 self.assertEqual(response.status_code, HTTPStatus.OK)
                 self.assertEqual(response['Content-Type'], 'text/csv; charset=UTF-8')

--- a/mtp_send_money/apps/send_money/views_misc.py
+++ b/mtp_send_money/apps/send_money/views_misc.py
@@ -91,7 +91,8 @@ class PerformanceDataCsvView(View):
 
         data = self.get_performance_data(date_from, date_to)
 
-        response = HttpResponse(content_type='text/csv')
+        response = HttpResponse(content_type='text/csv; charset=UTF-8')
+        response['Content-Disposition'] = 'attachment; filename="performance-data.csv"'
 
         writer = csv.DictWriter(response, fieldnames=data['headers'].keys())
         writer.writerow(data['headers'])

--- a/mtp_send_money/urls.py
+++ b/mtp_send_money/urls.py
@@ -46,7 +46,7 @@ urlpatterns += [
     url(r'^metrics.txt$', metrics_view, name='prometheus_metrics'),
 
     url(r'^robots.txt$', robots_txt_view),
-    url(r'^performance-data.csv$', PerformanceDataCsvView.as_view(), name='performance_platform_csv'),
+    url(r'^performance-data.csv$', PerformanceDataCsvView.as_view(), name='performance_data_csv'),
     url(r'^sitemap.xml$', SitemapXMLView.as_view(), name='sitemap_xml'),
 
     url(r'^\.well-known/security\.txt$', RedirectView.as_view(

--- a/mtp_send_money/urls.py
+++ b/mtp_send_money/urls.py
@@ -9,7 +9,13 @@ from moj_irat.views import HealthcheckView, PingJsonView
 from mtp_common.metrics.views import metrics_view
 
 from send_money.utils import CacheableTemplateView
-from send_money.views_misc import CookiesView, LegacyFeedbackView, SitemapXMLView, robots_txt_view
+from send_money.views_misc import (
+    CookiesView,
+    LegacyFeedbackView,
+    SitemapXMLView,
+    PerformanceDataCsvView,
+    robots_txt_view,
+)
 
 
 urlpatterns = i18n_patterns(
@@ -40,6 +46,7 @@ urlpatterns += [
     url(r'^metrics.txt$', metrics_view, name='prometheus_metrics'),
 
     url(r'^robots.txt$', robots_txt_view),
+    url(r'^performance-data.csv$', PerformanceDataCsvView.as_view(), name='performance_platform_csv'),
     url(r'^sitemap.xml$', SitemapXMLView.as_view(), name='sitemap_xml'),
 
     url(r'^\.well-known/security\.txt$', RedirectView.as_view(


### PR DESCRIPTION
Retrieve performance data from API (/performance/data) and converts/serve
the JSON data as CSV file.

Cache-Control header is set to encourage clients to cache the result
for a week (604,800 seconds) as this data gets updated roughly on a
weekly basis.

Ticket: https://dsdmoj.atlassian.net/browse/MTP-1894