### PR TITLE
MTP-1937: Removed dependency on `django-form-error-reporting` mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,5 @@ This is handled by [money-to-prisoners-deploy](https://github.com/ministryofjust
 
 There are several dependencies of the ``money-to-prisoners-send-money`` python library which are maintained by this team, so they may require code-changes when the dependencies (e.g. Django) of the ``money-to-prisoners-send-money`` python library are incremented.
 
-* django-form-error-reporting: https://github.com/ministryofjustice/django-form-error-reporting
 * django-zendesk-tickets: https://github.com/ministryofjustice/django-zendesk-tickets
 * django-moj-irat: https://github.com/ministryofjustice/django-moj-irat

--- a/mtp_send_money/apps/send_money/forms.py
+++ b/mtp_send_money/apps/send_money/forms.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator
 from django.utils.translation import gettext, gettext_lazy as _
-from form_error_reporting import GARequestErrorReportingMixin
 from mtp_common.auth.exceptions import HttpNotFoundError
 from mtp_common.forms.fields import SplitDateField
 from oauthlib.oauth2 import OAuth2Error, TokenExpiredError
@@ -24,7 +23,7 @@ from send_money.utils import (
 logger = logging.getLogger('mtp')
 
 
-class SendMoneyForm(GARequestErrorReportingMixin, forms.Form):
+class SendMoneyForm(forms.Form):
 
     @classmethod
     def unserialise_from_session(cls, request):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=14.3.0
+money-to-prisoners-common~=15.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=14.3.0
+money-to-prisoners-common[testing]~=15.0.0
 
 -r base.txt


### PR DESCRIPTION
Forms are not sending errors to GA anymore. Also bumped mtp-common to a version which doesn't install this package anymore.