### PR TITLE
MTP-1937: Updated cookies page with GA4 cookies

### DIFF
--- a/mtp_send_money/templates/cookies.html
+++ b/mtp_send_money/templates/cookies.html
@@ -71,7 +71,7 @@
         </thead>
         <tbody>
           <tr>
-            <td><code>_ga</code>, <code>_gat</code> {% trans 'and' %} <code>_gid</code></td>
+            <td><code>_ga</code> {% trans 'and' %} <code>_ga_&lt;container-id&gt;</code></td>
             <td>{% trans 'Lets Google Analytics know which pages you visit' %}</td>
             <td>{% trans 'Up to 2 years' %}</td>
           </tr>


### PR DESCRIPTION
GA4 only uses `_ga` and `_ga_<container-id>`.

See GA documentation: https://support.google.com/analytics/answer/11397207?hl=en