### PR TITLE
IR-1502 Update `setuptools` and upgrade AWS credentials action

### DIFF
--- a/.github/workflows/clean-ecr.yml
+++ b/.github/workflows/clean-ecr.yml
@@ -19,7 +19,7 @@ jobs:
           ref: main
 
       - name: Assume IAM role to access ECR
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.ECR_REGION }}
           role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,4 @@
 # Dependencies needed for all environments
 
 money-to-prisoners-common~=21.2.1
-# setuptools>=82 breaks pkg_resources import used by mtp_common build tooling
-setuptools<82
+


### PR DESCRIPTION
### Description

**Changes in this pull request:**
- Unpinned `setuptools` version in the base requirements file.
- Updated `aws-actions/configure-aws-credentials` GitHub Action from version 5 to 6. This includes various updates as per the [release notes](https://github.com/aws-actions/configure-aws-credentials/releases) and [changelog](https://github.com/aws-actions/configure-aws-credentials/blob/main/CHANGELOG.md).

### Checklist

- [ ] Ensure compatibility with the updated dependencies.
- [ ] Test workflows relying on `aws-actions/configure-aws-credentials`.
- [ ] Confirm that unpinning `setuptools` does not introduce issues. 