### PR TITLE
IR-1502 Bump money-to-prisoners-common to 21.2.2 in base and dev requirements files

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=21.2.1
+money-to-prisoners-common~=21.2.2
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=21.2.1
+money-to-prisoners-common[testing]~=21.2.2
 
 -r base.txt


### PR DESCRIPTION
Updated the `money-to-prisoners-common` library to version 21.2.2 in both the base and development requirements files. This ensures compatibility with recent changes and includes any relevant improvements or bug fixes.